### PR TITLE
Add guard before attempting to add a state <-> status mapping from statusmap.

### DIFF
--- a/src/MetadataShared/DataHelper.cs
+++ b/src/MetadataShared/DataHelper.cs
@@ -516,7 +516,10 @@ namespace DG.Tools.XrmMockup.Metadata
                 if (!dict.ContainsKey(logicalName)) {
                     dict.Add(logicalName, new Dictionary<int, int>());
                 }
-                dict[logicalName].Add(e.GetAttributeValue<int>("state"),e.GetAttributeValue<int>("status"));
+                var state = e.GetAttributeValue<int>("state");
+                if (!dict[logicalName].ContainsKey(state)) {
+                    dict[logicalName].Add(state, e.GetAttributeValue<int>("status"));
+                }
             }
 
             return dict;


### PR DESCRIPTION
In some cases, the objecttypecode "none" will be returned multiple times, with the same state <-> status mapping, resulting in a DuplicateKey exception.