### PR TITLE
Added comprehensive null check in Datahelper.cs GetSecurityRoles

### DIFF
--- a/src/MetadataShared/DataHelper.cs
+++ b/src/MetadataShared/DataHelper.cs
@@ -433,10 +433,17 @@ namespace DG.Tools.XrmMockup.Metadata
                 from rpr in res.DefaultIfEmpty()
                 select new { pp, rpr };
 
+            // Removing null entities
+            entities = entities
+                .Where(arg => arg.rpr != null && arg.pp != null)
+                .Where(arg => arg.rpr.role != null && arg.rpr.roleprivilege != null && arg.pp.privilegeOTC != null && arg.pp.privilege != null)
+                .Where(arg =>
+                    arg.pp.privilegeOTC.Attributes.ContainsKey("objecttypecode") &&
+                    arg.rpr.roleprivilege.Attributes.ContainsKey("roleid") &&
+                    arg.rpr.role.Attributes.ContainsKey("name"));
+
             // Role generation
             var roles = new Dictionary<Guid, SecurityRole>();
-
-            entities = entities.Where(arg => arg.rpr != null);
 
             foreach (var e in entities.Where(e => e.rpr.roleprivilege.Attributes.ContainsKey("roleid")))
             {

--- a/src/MetadataShared/DataHelper.cs
+++ b/src/MetadataShared/DataHelper.cs
@@ -433,19 +433,14 @@ namespace DG.Tools.XrmMockup.Metadata
                 from rpr in res.DefaultIfEmpty()
                 select new { pp, rpr };
 
-            // Removing null entities
-            entities = entities
-                .Where(arg => arg.rpr != null && arg.pp != null)
-                .Where(arg => arg.rpr.role != null && arg.rpr.roleprivilege != null && arg.pp.privilegeOTC != null && arg.pp.privilege != null)
-                .Where(arg =>
-                    arg.pp.privilegeOTC.Attributes.ContainsKey("objecttypecode") &&
-                    arg.rpr.roleprivilege.Attributes.ContainsKey("roleid") &&
-                    arg.rpr.role.Attributes.ContainsKey("name"));
-
             // Role generation
             var roles = new Dictionary<Guid, SecurityRole>();
 
-            foreach (var e in entities.Where(e => e.rpr.roleprivilege.Attributes.ContainsKey("roleid")))
+            foreach (var e in entities.Where(e =>
+                e.pp?.privilege != null &&
+                (e.pp?.privilegeOTC?.Contains("objecttypecode")).GetValueOrDefault() &&
+                (e.rpr?.roleprivilege?.Contains("roleid")).GetValueOrDefault() &&
+                (e.rpr?.role?.Contains("name")).GetValueOrDefault()))
             {
                 var entityName = (string)e.pp.privilegeOTC["objecttypecode"];
                 if (entityName == "none") continue;

--- a/src/MetadataShared/DataHelper.cs
+++ b/src/MetadataShared/DataHelper.cs
@@ -436,11 +436,13 @@ namespace DG.Tools.XrmMockup.Metadata
             // Role generation
             var roles = new Dictionary<Guid, SecurityRole>();
 
-            foreach (var e in entities.Where(e =>
+            var validSecurityRoles = entities.Where(e =>
                 e.pp?.privilege != null &&
                 (e.pp?.privilegeOTC?.Contains("objecttypecode")).GetValueOrDefault() &&
                 (e.rpr?.roleprivilege?.Contains("roleid")).GetValueOrDefault() &&
-                (e.rpr?.role?.Contains("name")).GetValueOrDefault()))
+                (e.rpr?.role?.Contains("name")).GetValueOrDefault());
+
+            foreach (var e in validSecurityRoles)
             {
                 var entityName = (string)e.pp.privilegeOTC["objecttypecode"];
                 if (entityName == "none") continue;


### PR DESCRIPTION
Is it too much to check if the entities contains the expected attributes?
If not, should we also check if the Attributes' value is null? 