### PR TITLE
Add support for triggering plugins on RetrieveMultipleRequests

### DIFF
--- a/src/XrmMockupShared/Core.cs
+++ b/src/XrmMockupShared/Core.cs
@@ -490,6 +490,13 @@ namespace DG.Tools.XrmMockup
             if (settings.TriggerProcesses && entityInfo != null)
             {
                 postImage = TryRetrieve(primaryRef);
+
+                // In RetrieveMultipleRequests, the OutputParameters bag contains the entity collection
+                if (request is RetrieveMultipleRequest)
+                {
+                    pluginContext.OutputParameters["BusinessEntityCollection"] = (response as RetrieveMultipleResponse)?.EntityCollection;
+                }
+
                 if (eventOp.HasValue)
                 {
                     pluginManager.TriggerSystem(eventOp.Value, ExecutionStage.PostOperation, entityInfo.Item1, preImage, postImage, pluginContext, this);
@@ -670,6 +677,34 @@ namespace DG.Tools.XrmMockup
                     ? (request as WinOpportunityRequest).OpportunityClose
                     : (request as LoseOpportunityRequest).OpportunityClose;
                 obj = close.GetAttributeValue<EntityReference>("opportunityid");
+            }
+            else if (request is RetrieveMultipleRequest)
+            {
+                var retrieve = request as RetrieveMultipleRequest;
+
+                string entityName = null;
+                switch (retrieve.Query)
+                {
+                    case FetchExpression fe:
+                        var qe = XmlHandling.FetchXmlToQueryExpression(fe.Query);
+                        entityName = qe.EntityName;
+                        break;
+                    case QueryExpression query:
+                        entityName = query.EntityName;
+                        break;
+                    case QueryByAttribute qba:
+                        entityName = qba.EntityName;
+                        break;
+                }
+                
+                if (entityName != null)
+                {
+                    return new Tuple<object, string, Guid>(new EntityReference
+                    {
+                        LogicalName = entityName,
+                        Id = Guid.Empty
+                    }, entityName, Guid.Empty);
+                }
             }
 
             if (obj != null)

--- a/src/XrmMockupShared/Mappings.cs
+++ b/src/XrmMockupShared/Mappings.cs
@@ -115,7 +115,8 @@ namespace DG.Tools.XrmMockup {
         };
 
 
-        public static EntityReference GetPrimaryEntityReferenceFromRequest(OrganizationRequest request) {
+        public static EntityReference GetPrimaryEntityReferenceFromRequest(OrganizationRequest request)
+        {
             if (request is RetrieveRequest) return ((RetrieveRequest)request).Target;
             if (request is CreateRequest) return ((CreateRequest)request).Target.ToEntityReferenceWithKeyAttributes();
             if (request is UpdateRequest) return ((UpdateRequest)request).Target.ToEntityReferenceWithKeyAttributes();
@@ -127,6 +128,15 @@ namespace DG.Tools.XrmMockup {
             if (request is MergeRequest) return ((MergeRequest)request).Target;
             if (request is WinOpportunityRequest) return ((WinOpportunityRequest)request).OpportunityClose.GetAttributeValue<EntityReference>("opportunityid");
             if (request is LoseOpportunityRequest) return ((LoseOpportunityRequest)request).OpportunityClose.GetAttributeValue<EntityReference>("opportunityid");
+            if (request is RetrieveMultipleRequest retrieve)
+            {
+                switch (retrieve.Query)
+                {
+                    case FetchExpression fe: return new EntityReference(XmlHandling.FetchXmlToQueryExpression(fe.Query).EntityName, Guid.Empty);
+                    case QueryExpression qe: return new EntityReference(qe.EntityName, Guid.Empty);
+                    case QueryByAttribute qba: return new EntityReference(qba.EntityName, Guid.Empty);
+                }
+            }
 
             return null;
         }

--- a/tests/SharedPluginsAndCodeactivites/LeadRetrieveMultiplePlugin.cs
+++ b/tests/SharedPluginsAndCodeactivites/LeadRetrieveMultiplePlugin.cs
@@ -1,0 +1,27 @@
+﻿using DG.XrmFramework.BusinessDomain.ServiceContext;
+using Microsoft.Xrm.Sdk;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace DG.Some.Namespace
+{
+    public class LeadRetrieveMultiplePlugin : Plugin
+    {
+        public LeadRetrieveMultiplePlugin() : base(typeof(LeadRetrieveMultiplePlugin))
+        {
+            RegisterPluginStep<Lead>(EventOperation.RetrieveMultiple, ExecutionStage.PostOperation, OnRetrieveMultiple);
+        }
+
+        private void OnRetrieveMultiple(LocalPluginContext ctx)
+        {
+            ctx.PluginExecutionContext.OutputParameters.TryGetValue("BusinessEntityCollection", out var ec);
+            if (ec == null) return;
+
+            var first = (ec as EntityCollection)?.Entities?.FirstOrDefault();
+            if (first != null)
+                first.Attributes["description"] = "*** TEST VALUE ***";
+        } 
+    }
+}

--- a/tests/SharedPluginsAndCodeactivites/SharedPluginsAndCodeactivites.projitems
+++ b/tests/SharedPluginsAndCodeactivites/SharedPluginsAndCodeactivites.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)AccountPreImagePlugin.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AccountSetStatePlugin.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AccountWorkflowActivity.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)LeadRetrieveMultiplePlugin.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)OpportunityWinLose.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PluginNonDaxif.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Plugin.cs" />

--- a/tests/SharedTests/TestRetrieveMultiple.cs
+++ b/tests/SharedTests/TestRetrieveMultiple.cs
@@ -574,6 +574,8 @@ namespace DG.XrmMockupTest {
             Assert.AreEqual(2, res.Count());
             Assert.IsTrue(res.Any(x => x.Id == lead1.Id));
             Assert.IsTrue(res.Any(x => x.Id == lead2.Id));
+            Assert.IsTrue(res.Any(x => x.Description == "*** TEST VALUE ***"));
+            Assert.IsTrue(res.Any(x => x.Description == null));
         }
 
         [TestMethod]


### PR DESCRIPTION
Make sure PrimaryEntityId and PrimaryEntityType are set when handling plugins for RetrieveMultipleRequests.
Make sure BusinessEntityCollection is set when calling into the PostOperation plugins