### PR TITLE
Recersive call to ConvertToComparableObject for AliasedValue

### DIFF
--- a/src/XrmMockupShared/Utility.cs
+++ b/src/XrmMockupShared/Utility.cs
@@ -605,7 +605,7 @@ namespace DG.Tools.XrmMockup
                 return money.Value;
 
             else if (obj is AliasedValue aliasedValue)
-                return aliasedValue.Value;
+                return ConvertToComparableObject(aliasedValue.Value);
 
             else if (obj is OptionSetValue optionSetValue)
                 return optionSetValue.Value;


### PR DESCRIPTION
For some linq expressions like:
```
var woQuery = from brb in ctx.BookableResourceBookingSet
  join wo in ctx.msdyn_workorderSet on brb.msdyn_WorkOrder.Id equals wo.Id
  where wo.msdyn_ServiceAccount.Id == accRef.Id
  select brb;
```
ConvertToComparableObject will sometimes return a wrong type.

In this case `EvaluateCondition` is detecting attr as an `AliasValue` and then return the value. In this case the value will be an EntityReference and not a `Guid`. 
To account for this and other cases, it is necessary to recersively call ConvertToComparableObject for AliasValues.