### PR TITLE
parallel performance improvements

### DIFF
--- a/src/XrmMockupShared/Database/DbRow.cs
+++ b/src/XrmMockupShared/Database/DbRow.cs
@@ -15,6 +15,8 @@ namespace DG.Tools.XrmMockup.Database {
         public Guid Id { get; set; }
         public bool IsDeleted { get; private set; } = false;
 
+        public int Sequence { get; set; }
+
         private Dictionary<string, object> Columns = new Dictionary<string, object>();
 #if !(XRM_MOCKUP_2011 || XRM_MOCKUP_2013 || XRM_MOCKUP_2015)
         private Dictionary<string, object> Keys = new Dictionary<string, object>();

--- a/src/XrmMockupShared/Database/XrmDb.cs
+++ b/src/XrmMockupShared/Database/XrmDb.cs
@@ -35,8 +35,8 @@ namespace DG.Tools.XrmMockup.Database {
             }
         }
 
-        public void Add(Entity xrmEntity, bool withReferenceChecks = true) {
-
+        public void Add(Entity xrmEntity, bool withReferenceChecks = true) 
+        {
             int nextSequence = Interlocked.Increment(ref sequence);
             var dbEntity = ToDbRow(xrmEntity,nextSequence, withReferenceChecks);
             this[dbEntity.Table.TableName][dbEntity.Id] = dbEntity;

--- a/src/XrmMockupShared/Requests/RetrieveMultipleRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/RetrieveMultipleRequestHandler.cs
@@ -45,7 +45,7 @@ namespace DG.Tools.XrmMockup {
             var entityMetadata = metadata.EntityMetadata[queryExpr.EntityName];
 
 #if !(XRM_MOCKUP_2011 || XRM_MOCKUP_2013)
-            var rowBag = new ConcurrentBag<DbRow>(rows);
+            var rowBag = new ConcurrentBag<DbRow>();
             //don't add the rows by passing in via the constructor as it can change the order
             foreach (var row in rows)
             {
@@ -107,29 +107,39 @@ namespace DG.Tools.XrmMockup {
                 throw new MockupException("Number of orders are greater than 2, unsupported in crm");
             } else if (orders.Count == 1) {
                 if (orders.First().OrderType == OrderType.Ascending)
-                    orderedCollection.Entities.AddRange(collection.OrderBy(x => Utility.GetComparableAttribute(x.Value.Attributes[orders[0].AttributeName])).Select(y => y.Value));
+                    orderedCollection.Entities.AddRange(collection.OrderBy(x => Utility.GetComparableAttribute(x.Value.Attributes[orders[0].AttributeName]))
+                        .ThenBy(x => x.Key.Sequence)
+                        .Select(y => y.Value));
                 else
                     orderedCollection.Entities.AddRange(collection.OrderByDescending(x => Utility.GetComparableAttribute(x.Value.Attributes[orders[0].AttributeName])).Select(y => y.Value));
             } else if (orders.Count == 2) {
                 if (orders[0].OrderType == OrderType.Ascending && orders[1].OrderType == OrderType.Ascending)
                     orderedCollection.Entities.AddRange(collection
                         .OrderBy(x => Utility.GetComparableAttribute(x.Value.Attributes[orders[0].AttributeName]))
-                        .ThenBy(x => Utility.GetComparableAttribute(x.Value.Attributes[orders[1].AttributeName])).Select(y => y.Value));
+                        .ThenBy(x => Utility.GetComparableAttribute(x.Value.Attributes[orders[1].AttributeName]))
+                        .ThenBy(x => x.Key.Sequence)
+                        .Select(y => y.Value));
 
                 else if (orders[0].OrderType == OrderType.Ascending && orders[1].OrderType == OrderType.Descending)
                     orderedCollection.Entities.AddRange(collection
                         .OrderBy(x => Utility.GetComparableAttribute(x.Value.Attributes[orders[0].AttributeName]))
-                        .ThenByDescending(x => Utility.GetComparableAttribute(x.Value.Attributes[orders[1].AttributeName])).Select(y => y.Value));
+                        .ThenByDescending(x => Utility.GetComparableAttribute(x.Value.Attributes[orders[1].AttributeName]))
+                        .ThenBy(x => x.Key.Sequence)
+                        .Select(y => y.Value));
 
                 else if (orders[0].OrderType == OrderType.Descending && orders[1].OrderType == OrderType.Ascending)
                     orderedCollection.Entities.AddRange(collection
                         .OrderByDescending(x => Utility.GetComparableAttribute(x.Value.Attributes[orders[0].AttributeName]))
-                        .ThenBy(x => Utility.GetComparableAttribute(x.Value.Attributes[orders[1].AttributeName])).Select(y => y.Value));
+                        .ThenBy(x => Utility.GetComparableAttribute(x.Value.Attributes[orders[1].AttributeName]))
+                        .ThenBy(x => x.Key.Sequence)
+                        .Select(y => y.Value));
 
                 else if (orders[0].OrderType == OrderType.Descending && orders[1].OrderType == OrderType.Descending)
                     orderedCollection.Entities.AddRange(collection
                         .OrderByDescending(x => Utility.GetComparableAttribute(x.Value.Attributes[orders[0].AttributeName]))
-                        .ThenByDescending(x => Utility.GetComparableAttribute(x.Value.Attributes[orders[1].AttributeName])).Select(y => y.Value));
+                        .ThenByDescending(x => Utility.GetComparableAttribute(x.Value.Attributes[orders[1].AttributeName]))
+                        .ThenBy(x => x.Key.Sequence)
+                        .Select(y => y.Value));
             }
 
             var colToReturn = new EntityCollection();

--- a/src/XrmMockupShared/Requests/RetrieveMultipleRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/RetrieveMultipleRequestHandler.cs
@@ -36,7 +36,7 @@ namespace DG.Tools.XrmMockup {
             }
 
             FillAliasIfEmpty(queryExpr);
-            //var collection = new EntityCollection();
+
             db.PrefillDBWithOnlineData(queryExpr);
             var rows = db.GetDBEntityRows(queryExpr.EntityName);
 
@@ -62,7 +62,6 @@ namespace DG.Tools.XrmMockup {
 
             var collection = new ConcurrentBag<KeyValuePair<DbRow, Entity>>();
 
-            // foreach (var row in rows)
             Parallel.ForEach(rows, row =>
             {
                 var entity = row.ToEntity();
@@ -145,7 +144,6 @@ namespace DG.Tools.XrmMockup {
             var colToReturn = new EntityCollection();
 
             if (orderedCollection.Entities.Count != 0) {
-                //foreach (var entity in orderedCollection.Entities) 
                 Parallel.ForEach(orderedCollection.Entities, entity =>
                 {
                     KeepAttributesAndAliasAttributes(entity, queryExpr.ColumnSet);
@@ -153,7 +151,6 @@ namespace DG.Tools.XrmMockup {
                 );
                 colToReturn = orderedCollection;
             } else {
-                // foreach (var entity in collection) {
                 Parallel.ForEach(collection, kvp =>
                 {
                     KeepAttributesAndAliasAttributes(kvp.Value, queryExpr.ColumnSet);

--- a/src/XrmMockupShared/Requests/RetrieveMultipleRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/RetrieveMultipleRequestHandler.cs
@@ -44,7 +44,6 @@ namespace DG.Tools.XrmMockup {
 
             var entityMetadata = metadata.EntityMetadata[queryExpr.EntityName];
 
-
 #if !(XRM_MOCKUP_2011 || XRM_MOCKUP_2013)
             var rowBag = new ConcurrentBag<DbRow>(rows);
             //don't add the rows by passing in via the constructor as it can change the order

--- a/src/XrmMockupShared/Utility.cs
+++ b/src/XrmMockupShared/Utility.cs
@@ -20,6 +20,7 @@ using Microsoft.Crm.Sdk.Messages;
 using System.IO;
 using DG.Tools.XrmMockup.Database;
 using System.Xml.Linq;
+using System.Collections.Concurrent;
 
 namespace DG.Tools.XrmMockup
 {
@@ -1060,20 +1061,19 @@ namespace DG.Tools.XrmMockup
 
         internal static void SetFormmattedValues(XrmDb db, Entity entity, EntityMetadata metadata)
         {
-            var validMetadata = metadata.Attributes
-                .Where(a => IsValidForFormattedValues(a));
+            var validMetadata = metadata.Attributes.Where(a => IsValidForFormattedValues(a));
 
-            var formattedValues = new List<KeyValuePair<string, string>>();
-            foreach (var a in entity.Attributes)
-            {
-                if (a.Value == null) continue;
-                var metadataAtt = validMetadata.Where(m => m.LogicalName == a.Key).FirstOrDefault();
-                var formattedValuePair = new KeyValuePair<string, string>(a.Key, Utility.GetFormattedValueLabel(db, metadataAtt, a.Value, entity));
-                if (formattedValuePair.Value != null)
-                {
-                    formattedValues.Add(formattedValuePair);
-                }
-            }
+            var formattedValues = new ConcurrentBag<KeyValuePair<string, string>>();
+
+            Parallel.ForEach(entity.Attributes.Where(x=>x.Value != null), a =>
+             {
+                 var metadataAtt = validMetadata.Where(m => m.LogicalName == a.Key).FirstOrDefault();
+                 var formattedValuePair = new KeyValuePair<string, string>(a.Key, Utility.GetFormattedValueLabel(db, metadataAtt, a.Value, entity));
+                 if (formattedValuePair.Value != null)
+                 {
+                     formattedValues.Add(formattedValuePair);
+                 }
+             });
 
             if (formattedValues.Count > 0)
             {

--- a/tests/SharedTests/TestRetrieveMultiple.cs
+++ b/tests/SharedTests/TestRetrieveMultiple.cs
@@ -189,7 +189,7 @@ namespace DG.XrmMockupTest
                 Assert.Equal(8, result.Count());
 
                 var ordered = result.OrderByDescending(x => x.Name).ThenBy(x => x.AccountId);
-                Assert.Equal(ordered.ToList(), result.ToList());
+                Assert.Equal(ordered.Select(x => x.Name).ToList(), result.Select(x => x.Name).ToList());
             }
         }
 

--- a/tests/SharedTests/TestRetrieveMultiple.cs
+++ b/tests/SharedTests/TestRetrieveMultiple.cs
@@ -189,7 +189,7 @@ namespace DG.XrmMockupTest
                 Assert.Equal(8, result.Count());
 
                 var ordered = result.OrderByDescending(x => x.Name).ThenBy(x => x.AccountId);
-                Assert.Equal(ordered.Select(x => x.Name).ToList(), result.Select(x => x.Name).ToList());
+                Assert.Equal(ordered.Select(x => new { x.Name, x.AccountId }).ToList(), result.Select(x => new { x.Name, x.AccountId }).ToList());
             }
         }
 


### PR DESCRIPTION
Fixes #174 

Added a sequence field to each row added (thread-safe) to allow RetrieveMultiple to return rows in the order created (Dynamics default behaviour if no sort order specified)

Parallelized and consolidated a number of the loops inside RetrieveMultipleRequestHandler.

These changes give no discernible improvements on XrmMockup's own test suite, but give something like a 30% increase on my own real world tests (29mins ->20mins)
