### PR TITLE
Handle duplicate access right for same security role

### DIFF
--- a/src/MetadataShared/DataHelper.cs
+++ b/src/MetadataShared/DataHelper.cs
@@ -444,6 +444,7 @@ namespace DG.Tools.XrmMockup.Metadata
             foreach (var e in validSecurityRoles)
             {
                 var entityName = (string)e.pp.privilegeOTC["objecttypecode"];
+
                 if (entityName == "none") continue;
 
                 var rp = ToRolePrivilege(e.pp.privilege, e.rpr.roleprivilege);
@@ -470,7 +471,10 @@ namespace DG.Tools.XrmMockup.Metadata
                     roles[roleId].Privileges.Add(entityName, new Dictionary<AccessRights, RolePrivilege>());
                 }
 
-                roles[roleId].Privileges[entityName].Add(rp.AccessRight, rp);
+                if(!roles[roleId].Privileges[entityName].ContainsKey(rp.AccessRight))
+                {
+                    roles[roleId].Privileges[entityName].Add(rp.AccessRight, rp);
+                }                
             }
             return roles;
         }

--- a/src/MetadataShared/DataHelper.cs
+++ b/src/MetadataShared/DataHelper.cs
@@ -240,7 +240,6 @@ namespace DG.Tools.XrmMockup.Metadata
                 .First(e => e.Id.Equals(baseOrganizationId));
         }
 
-
         internal IEnumerable<Entity> GetBusinessUnits()
         {
             var query = new QueryExpression("businessunit")
@@ -249,7 +248,6 @@ namespace DG.Tools.XrmMockup.Metadata
             };
             return service.RetrieveMultiple(query).Entities;
         }
-
 
         private IEnumerable<Guid> GetEntityComponentIdsFromSolution(string solutionName)
         {


### PR DESCRIPTION
The security role ServiceReader contains the same access right twice after what I assume is a faulty update by Microsoft. This change handles this error in the CRM data. 