### PR TITLE
Add sdkmessageprocessingstepid to pluginQuery.

### DIFF
--- a/src/MetadataShared/DataHelper.cs
+++ b/src/MetadataShared/DataHelper.cs
@@ -168,8 +168,9 @@ namespace DG.Tools.XrmMockup.Metadata
         {
             var pluginQuery = new QueryExpression("sdkmessageprocessingstep")
             {
-                ColumnSet = new ColumnSet("eventhandler", "stage", "mode", "rank", "sdkmessageid", "filteringattributes", "name", "impersonatinguserid"),
-                Criteria = new FilterExpression()
+                ColumnSet = new ColumnSet("eventhandler", "stage", "mode", "rank", "sdkmessageid", "filteringattributes", "name", "impersonatinguserid", "sdkmessageprocessingstepid"),
+                Criteria = new FilterExpression(),
+                Distinct = true,
             };
             pluginQuery.Criteria.AddCondition("statecode", ConditionOperator.Equal, 0);
 


### PR DESCRIPTION
In order to match the later retrieved entity images the id is required. so far it was always guid.empty. So I added the id to the query expression.