### PR TITLE
Add TargetType to SetEntityProperty actions.

### DIFF
--- a/src/XrmMockupWorkflow/ParseStructure.cs
+++ b/src/XrmMockupWorkflow/ParseStructure.cs
@@ -245,6 +245,10 @@ namespace WorkflowParser {
 
         [XmlAttribute("Value")]
         public string Value;
+
+        [XmlArray("SetEntityProperty.TargetType")]
+        [XmlArrayItem("InArgument")]
+        public Argument[] InArguments;
     }
 
     [XmlType("CreateEntity")]

--- a/src/XrmMockupWorkflow/WorkflowConstructor.cs
+++ b/src/XrmMockupWorkflow/WorkflowConstructor.cs
@@ -327,16 +327,21 @@ namespace WorkflowExecuter
         }
 
         private static IWorkflowNode CompressSetEntityProperty(WorkflowParser.SetEntityProperty setEntityProperty)
-        {
-            return new SetEntityProperty(setEntityProperty.Attribute, setEntityProperty.Entity.TrimEdge(), setEntityProperty.Value.TrimEdge());
+{
+            var targetTypeArg = setEntityProperty.InArguments?.First(a => a.ReferenceLiteral != null);
+            var targetType = targetTypeArg?.ReferenceLiteral?.Value?.Split(':')[1];
+
+            return new SetEntityProperty(setEntityProperty.Attribute, setEntityProperty.Entity.TrimEdge(), setEntityProperty.EntityName,
+                setEntityProperty.Value.TrimEdge(), targetType);
         }
 
         private static IWorkflowNode CompressGetEntityProperty(WorkflowParser.GetEntityProperty getEntityProperty)
         {
-            var targetType = getEntityProperty.InArguments?.First(a => a.ReferenceLiteral != null);
+            var targetTypeArg = getEntityProperty.InArguments?.First(a => a.ReferenceLiteral != null);
+            var targetType = targetTypeArg?.ReferenceLiteral?.Value?.Split(':')[1];
 
             return new GetEntityProperty(getEntityProperty.Attribute, getEntityProperty.Entity.TrimEdge(), getEntityProperty.EntityName,
-                getEntityProperty.Value.TrimEdge(), targetType?.ReferenceLiteral?.Value?.Split(':')[1]);
+                getEntityProperty.Value.TrimEdge(), targetType);
         }
 
         private static IWorkflowNode CompressTerminateWorkflow(WorkflowParser.TerminateWorkflow terminateWorkflow)

--- a/src/XrmMockupWorkflow/WorkflowTree.cs
+++ b/src/XrmMockupWorkflow/WorkflowTree.cs
@@ -983,7 +983,20 @@ namespace WorkflowExecuter
                 return;
             }
 
-            variables[VariableName] = entity.Attributes[Attribute];
+            var attr = entity.Attributes[Attribute];
+            if (TargetType == "EntityReference")
+            {
+                if (attr is Guid guid)
+                {
+                    attr = new EntityReference(EntityLogicalName, guid);
+                }
+                else if (!(attr is EntityReference))
+                {
+                    throw new InvalidCastException($"Cannot convert {attr.GetType().Name} to {TargetType}");
+                }
+            }
+
+            variables[VariableName] = attr;
         }
     }
 


### PR DESCRIPTION
Respect TargetType when assigning final value to entity.
Do not translate type when reading from entity.

The TargetType property is propagated from the end-target to any input values.
This was used to cast the input values, but that would result in the types being wrong during computation.
Instead, cast to the target type before writing the value in `SetEntityProperty`.

This was observed in new `caseage` calculated field added as part of release wave 2