### PR TITLE
Add support for .NET6 by multi-targeting XrmMockup365

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,3 @@
-image: Visual Studio 2019
+image: Visual Studio 2022
 build_script:
 - cmd: build.cmd test

--- a/src/XrmMockup365/XrmMockup365.csproj
+++ b/src/XrmMockup365/XrmMockup365.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Library</OutputType>
-        <TargetFramework>net462</TargetFramework>
+        <TargetFrameworks>net462;net6.0</TargetFrameworks>
         <DebugType>portable</DebugType>
         <Title>XrmMockup365</Title>
     </PropertyGroup>
@@ -29,7 +29,10 @@
         <DefineConstants>TRACE;XRM_MOCKUP_365</DefineConstants>
         <ErrorReport>prompt</ErrorReport>
     </PropertyGroup>
-    <ItemGroup>
+	<PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<DefineConstants>$(DefineConstants);DATAVERSE_SERVICE_CLIENT</DefineConstants>
+	</PropertyGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
         <Reference Include="System" />
         <Reference Include="System.Activities" />
         <Reference Include="System.configuration" />
@@ -44,17 +47,23 @@
         <Reference Include="System.Xml" />
     </ItemGroup>
     <ItemGroup>
-        <Content Include="..\MetadataGen\MetadataGenerator365\bin\Release\$(TargetFramework)\MetadataGenerator365.exe" Pack="true" PackagePath="content\net462\Metadata" />
-        <Content Include="..\MetadataGen\MetadataGenerator365\bin\Release\$(TargetFramework)\MetadataGenerator365.exe.config" Pack="true" PackagePath="content\net462\Metadata" />
-        <Content Include="..\..\files\TypeDeclarations.cs" Pack="true" PackagePath="content\net462\Metadata" />
+        <Content Include="..\MetadataGen\MetadataGenerator365\bin\Release\net462\MetadataGenerator365.exe" Pack="true" PackagePath="content\$(TargetFramework)\Metadata" />
+        <Content Include="..\MetadataGen\MetadataGenerator365\bin\Release\net462\MetadataGenerator365.exe.config" Pack="true" PackagePath="content\$(TargetFramework)\Metadata" />
+        <Content Include="..\..\files\TypeDeclarations.cs" Pack="true" PackagePath="content\$(TargetFramework)\Metadata" />
         <None Include="..\..\resources\XrmMockup-sticker_small.png" Pack="true" PackagePath="" />
     </ItemGroup>
-    <ItemGroup>
+    <ItemGroup Condition="'$(TargetFramework)' == 'net462'">
         <PackageReference Include="Microsoft.CrmSdk.CoreAssemblies" Version="9.0.2.28" />
         <PackageReference Include="Microsoft.CrmSdk.Workflow" Version="9.0.2.28" />
         <PackageReference Include="Microsoft.CrmSdk.XrmTooling.CoreAssembly" Version="9.1.0.51" />
-        <PackageReference Include="System.Text.Json" Version="6.0.2" />
     </ItemGroup>
+	<ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.0.1" />
+		<PackageReference Include="UiPath.Workflow" Version="6.0.3" />
+	</ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="System.Text.Json" Version="6.0.2" />
+	</ItemGroup>
     <Import Project="..\XrmMockupShared\XrmMockupShared.projitems" Label="Shared" />
     <Import Project="..\XrmMockupWorkflow\XrmMockupWorkflow.projitems" Label="Shared" />
     <Import Project="..\MetadataSkeleton\MetadataSkeleton.projitems" Label="Shared" />

--- a/src/XrmMockupShared/Database/OrganizationHelper.cs
+++ b/src/XrmMockupShared/Database/OrganizationHelper.cs
@@ -37,7 +37,11 @@ namespace DG.Tools.XrmMockup {
 
         public OrganizationServiceProxy GetServiceProxy() {
             var proxy = GetServiceProxyInternal();
+#if DATAVERSE_SERVICE_CLIENT
+            proxy.ServiceConfiguration.CurrentServiceEndpoint.EndpointBehaviors.Add(new ProxyTypesBehavior());
+#else
             proxy.ServiceConfiguration.CurrentServiceEndpoint.Behaviors.Add(new ProxyTypesBehavior());
+#endif
             proxy.Timeout = new TimeSpan(1, 0, 0);
             return proxy;
         }

--- a/src/XrmMockupShared/MockupService.cs
+++ b/src/XrmMockupShared/MockupService.cs
@@ -5,10 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Query;
-using Microsoft.Xrm.Sdk.Client;
-using System.Reflection;
 using Microsoft.Xrm.Sdk.Messages;
-using Microsoft.Crm.Sdk.Messages;
 using System.ServiceModel;
 
 namespace DG.Tools.XrmMockup {

--- a/src/XrmMockupShared/MockupServiceAsync.cs
+++ b/src/XrmMockupShared/MockupServiceAsync.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.Xrm.Sdk;
+using System.Threading.Tasks;
+using Microsoft.Xrm.Sdk.Query;
+#if DATAVERSE_SERVICE_CLIENT
+using Microsoft.PowerPlatform.Dataverse.Client;
+#endif
+
+namespace DG.Tools.XrmMockup
+{
+#if DATAVERSE_SERVICE_CLIENT
+    /// <summary>
+    /// A class for Mocking the IOrganizationServiceAsync when exposing through the Dataverse Client
+    /// </summary>
+    internal partial class MockupService : IOrganizationServiceAsync
+    {
+        public Task AssociateAsync(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities)
+        {
+            Associate(entityName, entityId, relationship, relatedEntities);
+            return Task.CompletedTask;
+        }
+
+        public Task<Guid> CreateAsync(Entity entity)
+        {
+            return Task.FromResult(Create(entity));
+        }
+
+        public Task DeleteAsync(string entityName, Guid id)
+        {
+            Delete(entityName, id);
+            return Task.CompletedTask;
+        }
+
+        public Task DisassociateAsync(string entityName, Guid entityId, Relationship relationship, EntityReferenceCollection relatedEntities)
+        {
+            Disassociate(entityName, entityId, relationship, relatedEntities);
+            return Task.CompletedTask;
+        }
+
+        public Task<OrganizationResponse> ExecuteAsync(OrganizationRequest request)
+        {
+            return Task.FromResult(Execute(request));
+        }
+
+        public Task<Entity> RetrieveAsync(string entityName, Guid id, ColumnSet columnSet)
+        {
+            return Task.FromResult(Retrieve(entityName, id, columnSet));
+        }
+
+        public Task<EntityCollection> RetrieveMultipleAsync(QueryBase query)
+        {
+            return Task.FromResult(RetrieveMultiple(query));
+        }
+
+        public Task UpdateAsync(Entity entity)
+        {
+            Update(entity);
+            return Task.CompletedTask;
+        }
+    }
+#endif
+}

--- a/src/XrmMockupShared/MockupServiceProviderAndFactory.cs
+++ b/src/XrmMockupShared/MockupServiceProviderAndFactory.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Xrm.Sdk;
+﻿#if DATAVERSE_SERVICE_CLIENT
+using Microsoft.PowerPlatform.Dataverse.Client;
+#endif
+using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Query;
 using System;
 using System.Collections.Generic;
@@ -61,5 +64,32 @@ namespace DG.Tools.XrmMockup {
         public IOrganizationService CreateAdminOrganizationService(MockupServiceSettings settings) {
             return new MockupService(core, null, this.pluginContext, settings);
         }
+
+#if DATAVERSE_SERVICE_CLIENT
+        /// <summary>
+        /// Returns a new MockupService with the given userId, or standard user if null. 
+        /// </summary>
+        /// <param name="userId"></param>
+        /// <returns></returns>
+        public IOrganizationServiceAsync CreateOrganizationServiceAsync(Guid? userId)
+        {
+            return new MockupService(core, userId, this.pluginContext);
+        }
+
+        public IOrganizationServiceAsync CreateOrganizationServiceAsync(Guid? userId, MockupServiceSettings settings)
+        {
+            return new MockupService(core, userId, this.pluginContext, settings);
+        }
+
+        public IOrganizationServiceAsync CreateAdminOrganizationServiceAsync()
+        {
+            return new MockupService(core, null, this.pluginContext);
+        }
+
+        public IOrganizationServiceAsync CreateAdminOrganizationServiceAsync(MockupServiceSettings settings)
+        {
+            return new MockupService(core, null, this.pluginContext, settings);
+        }
+#endif
     }
 }

--- a/src/XrmMockupShared/XrmMockupBase.cs
+++ b/src/XrmMockupShared/XrmMockupBase.cs
@@ -8,7 +8,6 @@ using Microsoft.Xrm.Sdk.Metadata;
 using Microsoft.Xrm.Sdk.Query;
 using Microsoft.Crm.Sdk.Messages;
 using System.IO;
-using System.Runtime.CompilerServices;
 
 namespace DG.Tools.XrmMockup
 {
@@ -17,7 +16,7 @@ namespace DG.Tools.XrmMockup
     /// <summary>
     /// A Mockup of a CRM instance
     /// </summary>
-    public abstract class XrmMockupBase {
+    public abstract partial class XrmMockupBase {
 
         /// <summary>
         /// AdminUser for the Mockup instance

--- a/src/XrmMockupShared/XrmMockupBaseAsync.cs
+++ b/src/XrmMockupShared/XrmMockupBaseAsync.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+#if DATAVERSE_SERVICE_CLIENT
+using Microsoft.PowerPlatform.Dataverse.Client;
+#endif
+
+namespace DG.Tools.XrmMockup
+{
+#if DATAVERSE_SERVICE_CLIENT
+    public abstract partial class XrmMockupBase
+    {
+        /// <summary>
+        /// Create an async organization service for the systemuser with the given id
+        /// </summary>
+        /// <param name="userId"></param>
+        /// <returns></returns>
+        public IOrganizationServiceAsync CreateOrganizationServiceAsync(Guid userId)
+        {
+            return ServiceFactory.CreateOrganizationServiceAsync(userId);
+        }
+
+        /// <summary>
+        /// Create an async organization service, with the given settings, for the systemuser with the given id
+        /// </summary>
+        /// <param name="userId"></param>
+        /// <param name="settings"></param>
+        /// <returns></returns>
+        public IOrganizationServiceAsync CreateOrganizationServiceAsync(Guid userId, MockupServiceSettings settings)
+        {
+            return ServiceFactory.CreateOrganizationServiceAsync(userId, settings);
+        }
+
+        /// <summary>
+        /// Gets an async system administrator organization service
+        /// </summary>
+        /// <returns></returns>
+        public IOrganizationServiceAsync GetAdminServiceAsync()
+        {
+            return ServiceFactory.CreateAdminOrganizationServiceAsync();
+        }
+
+        /// <summary>
+        /// Gets an async system administrator organization service, with the given settings
+        /// </summary>
+        /// <param name="Settings"></param>
+        /// <returns></returns>
+        public IOrganizationServiceAsync GetAdminServiceAsync(MockupServiceSettings Settings)
+        {
+            return ServiceFactory.CreateAdminOrganizationServiceAsync(Settings);
+        }
+    }
+#endif
+}

--- a/src/XrmMockupShared/XrmMockupShared.projitems
+++ b/src/XrmMockupShared/XrmMockupShared.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Database\DbAttributeTypeMap.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Database\DbRow.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Database\DbTable.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)MockupServiceAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\DbDTO.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\OptionSetCollectionDTO.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\EntityReferenceDTO.cs" />
@@ -81,6 +82,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Workflow\WorkflowManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)XmlHandling.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)XrmMockupBase.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)XrmMockupBaseAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)XrmMockupSettings.cs" />
   </ItemGroup>
 </Project>

--- a/src/XrmMockupWorkflow/IWorkflowContext.cs
+++ b/src/XrmMockupWorkflow/IWorkflowContext.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+#if DATAVERSE_SERVICE_CLIENT
+namespace Microsoft.Xrm.Sdk.Workflow
+{
+    //
+    // Summary:
+    //     Provides access to the data associated with the process instance.
+    public interface IWorkflowContext : IExecutionContext
+    {
+        //
+        // Summary:
+        //     Gets the stage information of the process instance.
+        //
+        // Returns:
+        //     Type: String The stage information of the process instance.
+        string StageName { get; }
+
+        //
+        // Summary:
+        //     Gets the process category information of the process instance: workflow or dialog.
+        //
+        // Returns:
+        //     Type: Int32 The process category information of the process instance: workflow
+        //     or dialog.
+        int WorkflowCategory { get; }
+
+        //
+        // Summary:
+        //     Indicates how the workflow is to be executed.
+        //
+        // Returns:
+        //     Type: Int32 Value = 0 (background/asynchronous), 1 (real-time).
+        int WorkflowMode { get; }
+
+        //
+        // Summary:
+        //     Gets the parent context.
+        //
+        // Returns:
+        //     Type: Microsoft.Xrm.Sdk.Workflow.IWorkflowContext The parent context.
+        IWorkflowContext ParentContext { get; }
+    }
+}
+#endif

--- a/src/XrmMockupWorkflow/XrmMockupWorkflow.projitems
+++ b/src/XrmMockupWorkflow/XrmMockupWorkflow.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>XrmMockupWorkflow</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)IWorkflowContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NamespaceIgnoreXmlReader.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Parser.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ParseStructure.cs" />
@@ -16,6 +17,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)WorkflowConstructor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkflowException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WorkflowTree.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)XrmTimeSpan.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)XrmWorkflowContext.cs" />
   </ItemGroup>
 </Project>

--- a/src/XrmMockupWorkflow/XrmTimeSpan.cs
+++ b/src/XrmMockupWorkflow/XrmTimeSpan.cs
@@ -1,0 +1,316 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+#if DATAVERSE_SERVICE_CLIENT
+namespace Microsoft.Xrm.Sdk.Workflow
+{
+    //
+    // Summary:
+    //     Represents a time interval.
+    [Serializable]
+    public struct XrmTimeSpan
+    {
+        //
+        // Summary:
+        //     Represents the zero XrmTimeSpan value. This field is read-only.
+        public static readonly XrmTimeSpan Zero = new XrmTimeSpan(0, 0, 0, 0, 0);
+
+        //
+        // Summary:
+        //     Gets the number of whole years represented by the current XrmTimeSpan structure.
+        //
+        // Returns:
+        //     Type: Int32 The number of whole years represented by the current XrmTimeSpan
+        //     structure.
+        public int Years { get; set; }
+
+        //
+        // Summary:
+        //     Gets the number of whole months represented by the current XrmTimeSpan structure.
+        //
+        // Returns:
+        //     Type: Int32 The number of whole months represented by the current XrmTimeSpan
+        //     structure.
+        public int Months { get; set; }
+
+        //
+        // Summary:
+        //     Gets the number of whole days represented by the current XrmTimeSpan structure.
+        //
+        // Returns:
+        //     Type: Int32 The number of whole days represented by the current XrmTimeSpan structure.
+        public int Days { get; set; }
+
+        //
+        // Summary:
+        //     Gets the number of whole hours represented by the current XrmTimeSpan structure.
+        //
+        // Returns:
+        //     Type: Int32 The number of whole hours represented by the current XrmTimeSpan
+        //     structure.
+        public int Hours { get; set; }
+
+        //
+        // Summary:
+        //     Gets the number of whole minutes represented by the current XrmTimeSpan structure.
+        //
+        // Returns:
+        //     Type: Int32 The number of whole minutes represented by the current XrmTimeSpan
+        //     structure.
+        public int Minutes { get; set; }
+
+        //
+        // Summary:
+        //     Initializes a new instance of the CrmTimeSpan class setting the time span.
+        //
+        // Parameters:
+        //   value:
+        //     Type: TimeSpan. Specifies the time span.
+        public XrmTimeSpan(TimeSpan value)
+        {
+            Years = 0;
+            Months = 0;
+            Days = value.Days;
+            Hours = value.Days;
+            Minutes = value.Days;
+        }
+
+        //
+        // Summary:
+        //     Initializes a new instance of the XrmTimeSpan class setting the days, hours and
+        //     minutes.
+        //
+        // Parameters:
+        //   days:
+        //     Type: Int32. Specifies the days for the time span.
+        //
+        //   hours:
+        //     Type: Int32. Specifies the hours for the time span.
+        //
+        //   minutes:
+        //     Type: Int32. Specifies the minutes for the time span.
+        public XrmTimeSpan(int days, int hours, int minutes)
+        {
+            Years = 0;
+            Months = 0;
+            Days = days;
+            Hours = hours;
+            Minutes = minutes;
+        }
+
+        //
+        // Summary:
+        //     Initializes a new instance of the XrmTimeSpan class setting the years, months,
+        //     days, hours and minutes.
+        //
+        // Parameters:
+        //   years:
+        //     Type: Int32. Specifies the years for the time span.
+        //
+        //   months:
+        //     Type: Int32. Specifies the months for the time span.
+        //
+        //   days:
+        //     Type: Int32. Specifies the days for the time span.
+        //
+        //   hours:
+        //     Type: Int32. Specifies the hours for the time span.
+        //
+        //   minutes:
+        //     Type: Int32. Specifies the minutes for the time span.
+        public XrmTimeSpan(int years, int months, int days, int hours, int minutes)
+        {
+            Years = years;
+            Months = months;
+            Days = days;
+            Hours = hours;
+            Minutes = minutes;
+        }
+
+        //
+        // Summary:
+        //     Creates an instance of a XrmTimeSpan class setting the days, hours and minutes.
+        //
+        // Parameters:
+        //   days:
+        //     Type: Int32. Specifies the days for the time span.
+        //
+        //   hours:
+        //     Type: Int32. Specifies the hours for the time span.
+        //
+        //   minutes:
+        //     Type: Int32. Specifies the minutes for the time span.
+        //
+        // Returns:
+        //     Type: Microsoft.Xrm.Sdk.Workflow.XrmTimeSpan The instance of a XrmTimeSpan class
+        //     where the days, hours, and minutes are set.
+        public static XrmTimeSpan CreateXrmTimeSpan(int days, int hours, int minutes)
+        {
+            return new XrmTimeSpan(days, hours, minutes);
+        }
+
+        //
+        // Summary:
+        //     Creates an instance of a XrmTimeSpan class setting the years, months, days, hours
+        //     and minutes.
+        //
+        // Parameters:
+        //   years:
+        //     Type: Int32. Specifies the years for the time span.
+        //
+        //   months:
+        //     Type: Int32. Specifies the months for the time span.
+        //
+        //   days:
+        //     Type: Int32. Specifies the days for the time span.
+        //
+        //   hours:
+        //     Type: Int32. Specifies the hours for the time span.
+        //
+        //   minutes:
+        //     Type: Int32. Specifies the minutes for the time span.
+        //
+        // Returns:
+        //     Type: Microsoft.Xrm.Sdk.Workflow.XrmTimeSpan The instance of a XrmTimeSpan class
+        //     where the years, months, days, hours, and minutes are set.
+        public static XrmTimeSpan CreateXrmTimeSpan(int years, int months, int days, int hours, int minutes)
+        {
+            return new XrmTimeSpan(years, months, days, hours, minutes);
+        }
+
+        //
+        // Summary:
+        //     Creates an instance of a XrmTimeSpan class setting the time span members.
+        //
+        // Parameters:
+        //   cts:
+        //     Type: Microsoft.Xrm.Sdk.Workflow.XrmTimeSpan. Specifies the time span.
+        //
+        // Returns:
+        //     Type: Microsoft.Xrm.Sdk.Workflow.XrmTimeSpan The instance of a XrmTimeSpan class
+        //     where the time span members are set.
+        public static XrmTimeSpan CreateXrmTimeSpan(XrmTimeSpan cts)
+        {
+            return new XrmTimeSpan(cts.Years, cts.Months, cts.Days, cts.Hours, cts.Minutes);
+        }
+
+        //
+        // Summary:
+        //     Returns a value indicating whether this instance is equal to a specified XrmTimeSpan
+        //     object.
+        //
+        // Parameters:
+        //   value:
+        //     Type: Microsoft.Xrm.Sdk.Workflow.XrmTimeSpan. Specifies the XrmTimeSpan instance
+        //     to test for equality with the current instance.
+        //
+        // Returns:
+        //     Type: Boolean true if the value represents the same time interval as the current
+        //     XrmTimeSpan structure; otherwise, false.
+        public bool Equals(XrmTimeSpan value)
+        {
+            return value.Years == Years && value.Months == Months && value.Days == Days && value.Hours == Hours && value.Minutes == Minutes;
+        }
+
+        //
+        // Summary:
+        //     Returns a value indicating whether this instance is equal to a specified object.
+        //
+        // Parameters:
+        //   obj:
+        //     Type: Object. Specifies the object to test for equality with the current instance.
+        //
+        // Returns:
+        //     Type: Boolean true if value is a XrmTimeSpan object that represents the same
+        //     time interval as the current XrmTimeSpan structure; otherwise, false.
+        public override bool Equals(object obj)
+        {
+            return Equals((XrmTimeSpan)obj);
+        }
+
+        //
+        // Summary:
+        //     Returns a hash code for this instance.
+        //
+        // Returns:
+        //     Type: Int32 The hash code for this instance.
+        public override int GetHashCode()
+        {
+            return Years ^ Months ^ Days ^ Hours ^ Minutes;
+        }
+
+        //
+        // Summary:
+        //     Indicates whether two XrmTimeSpan instances are equal.
+        //
+        // Parameters:
+        //   span1:
+        //     Type: Microsoft.Xrm.Sdk.Workflow.XrmTimeSpan. Specifies a XrmTimeSpan.
+        //
+        //   span2:
+        //     Type: Microsoft.Xrm.Sdk.Workflow.XrmTimeSpan. Specifies a XrmTimeSpan.
+        //
+        // Returns:
+        //     Type: Boolean true if the values of span1 and span2 are equal; otherwise, false.
+        public static bool operator ==(XrmTimeSpan span1, XrmTimeSpan span2)
+        {
+            return span1.Equals(span2);
+        }
+
+        //
+        // Summary:
+        //     Indicates whether two XrmTimeSpan instances are not equal.
+        //
+        // Parameters:
+        //   span1:
+        //     Type: Microsoft.Xrm.Sdk.Workflow.XrmTimeSpan. Specifies a XrmTimeSpan.
+        //
+        //   span2:
+        //     Type: Microsoft.Xrm.Sdk.Workflow.XrmTimeSpan. Specifies a XrmTimeSpan.
+        //
+        // Returns:
+        //     Type: Boolean true if the values of span1 and span2 are not equal; otherwise,
+        //     false.
+        public static bool operator !=(XrmTimeSpan span1, XrmTimeSpan span2)
+        {
+            return !(span1 == span2);
+        }
+
+        //
+        // Summary:
+        //     Adds the specified date/time value to this instance.
+        //
+        // Parameters:
+        //   value:
+        //     Type: DateTime. A date/time value to add to the current instance value.
+        //
+        // Returns:
+        //     Type: DateTime The resultant date and time value.
+        public DateTime Add(DateTime value)
+        {
+            return value.AddYears(Years).AddMonths(Months).AddDays(Days)
+                .AddHours(Hours)
+                .AddMinutes(Minutes);
+        }
+
+        //
+        // Summary:
+        //     Subtracts the specified XrmTimeSpan from this instance.
+        //
+        // Parameters:
+        //   value:
+        //     Type: DateTime. Specifies a date/time value to subtract.
+        //
+        // Returns:
+        //     Type: DateTime The value resulting when the passed value is subtracted from this
+        //     instance.
+        public DateTime Subtract(DateTime value)
+        {
+            return value.AddYears(-1 * Years).AddMonths(-1 * Months).AddDays(-1 * Days)
+                .AddHours(-1 * Hours)
+                .AddMinutes(-1 * Minutes);
+        }
+    }
+}
+#endif


### PR DESCRIPTION
Add .NET6 target to  XrmMockup365 project.
Add compile-time constant and include Dataverse Service Client if compiling for .NET6
Implement IOrganizationServiceAsync, included in Dataverse Service Client

This fixes #189 