### PR TITLE
Fixed error where the same DLL could be loaded multiple times

### DIFF
--- a/src/XrmMockupShared/XrmMockupBase.cs
+++ b/src/XrmMockupShared/XrmMockupBase.cs
@@ -97,7 +97,7 @@ namespace DG.Tools.XrmMockup
             string path = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
             foreach (string dll in Directory.GetFiles(path, "*.dll"))
             {
-                var asm = Assembly.LoadFile(dll);
+                var asm = Assembly.LoadFrom(dll);
                 if (addedAssemblies.Contains(asm.FullName)) continue;
 
                 assemblies.Add(asm);


### PR DESCRIPTION
I tried using XrmMockup in .NET 6 with the new update. It almost worked.

For some reason XrmMockup saw the path to the same assembly multiple times. Which caused it to load the same DLL multiple times.

This is possible because we use the method `Assembly.LoadFile` instead of `Assembly.LoadFrom`. This SO post lead me down that road to fix it https://stackoverflow.com/questions/56146804/assembly-loading-happens-twice

I changed that method, tested XrmMockup365 locally, and it works in my project now as well as all the tests in XrmMockup.