### PR TITLE
Improve logging

### DIFF
--- a/src/XrmMockupShared/TracingService.cs
+++ b/src/XrmMockupShared/TracingService.cs
@@ -1,21 +1,29 @@
 ﻿using Microsoft.Xrm.Sdk;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 namespace DG.Tools.XrmMockup {
-    internal class TracingService : ITracingService {
-        public void Trace(string format, params object[] args) {
-			try
-			{
-				Console.WriteLine(format, args);
-			}
-			catch 
-			{
-				Console.WriteLine(format);
-			}
+    internal class TracingService : ITracingService
+    {
+        static TracingService()
+        {
+            //Enable mstest output to test results by using Trace.
+            System.Diagnostics.Trace.Listeners.Add(new ConsoleTraceListener());
+        }
+        public void Trace(string format, params object[] args)
+        {
+            try
+            {
+                System.Diagnostics.Trace.WriteLine(string.Format(format, args));
+            }
+            catch
+            {
+                System.Diagnostics.Trace.WriteLine(format);
+            }
         }
     }
 }

--- a/src/XrmMockupWorkflow/WorkflowConstructor.cs
+++ b/src/XrmMockupWorkflow/WorkflowConstructor.cs
@@ -24,7 +24,7 @@ namespace WorkflowExecuter
         {
             if (workflow == null || workflow.LogicalName != LogicalNames.Workflow)
             {
-                throw new WorkflowException($"Entity had logicalname '{LogicalNames.Workflow}' instead of workflow");
+                throw new WorkflowException($"Entity had logicalname '{workflow.LogicalName}' instead of {LogicalNames.Workflow}");
             }
             var parsed = Parser.Parse(workflow.GetAttributeValue<string>("xaml"));
             var triggerFields = new HashSet<string>();

--- a/src/XrmMockupWorkflow/WorkflowConstructor.cs
+++ b/src/XrmMockupWorkflow/WorkflowConstructor.cs
@@ -46,7 +46,7 @@ namespace WorkflowExecuter
                workflow.GetOptionSetValue<workflow_stage>("createstage"), workflow.GetOptionSetValue<workflow_stage>("updatestage"),
                workflow.GetOptionSetValue<workflow_stage>("deletestage"), workflow.GetOptionSetValue<Workflow_Mode>("mode"),
                workflow.GetAttributeValue<EntityReference>("ownerid").Id, workflow.GetAttributeValue<string>("primaryentity"), codeActivites,
-               input, output);
+               input, output, workflow.GetAttributeValue<string>("name"));
         }
 
         private static WorkflowArgument ConvertToArgument(Property p)


### PR DESCRIPTION
Solves https://github.com/delegateas/XrmMockup/issues/223

Adds such logging information:

```
...
Background workflow 'Some workflow name #2' completed successfully
Starting Background workflow: 'Some workflow name 2' for entity 'entity'. timeOffset: 00:00:00
Entering ActivityList. Activities Count: 32 VariableNames: 
Entering ActivityList
Entering CreateVariable. VariableName: ConditionBranchStep2_condition
Entering CreateVariable. VariableName: ConditionBranchStep2_1
Entering CreateVariable. VariableName: ConditionBranchStep2_5
Entering GetEntityProperty. Attribute: statuscode EntityId: InputEntities("primaryEntity") EntityLogicalName: entity....
Entering ActivityList. Activities Count: 6 VariableNames: 
Entering ActivityList
Entering Skip
Entering CreateVariable. VariableName: stepLabelLabelId
Entering CreateVariable. VariableName: stepLabelDescription
Entering CreateVariable. VariableName: stepLabelLanguageCode
Entering CreateVariable. VariableName: StopWorkflowStep3_1
Entering TerminateWorkflow. Status: TerminateWorkflow MessageId: Succeeded
Entering CreateVariable. VariableName: CustomActivityStep4_1
Entering ConvertType. Input: CustomActivityStep4_1, Type: String, Result: CustomActivityStep4_1_converted
Entering CreateVariable. VariableName: CustomActivityStep4_2
Entering ConvertType. Input: CustomActivityStep4_2, Type: Boolean, Result: CustomActivityStep4_2_converted
Entering CallCodeActivity. CodeActivityName: GetPostEntityImageValue
Exception thrown: 'System.Collections.Generic.KeyNotFoundException' in mscorlib.dll
An exception of type 'System.Collections.Generic.KeyNotFoundException' occurred in mscorlib.dll but was not handled in user code
The given key was not present in the dictionary.
```