### PR TITLE
Add parameter to mitigate duplicate security roles names by appending…

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 1.12.1 - 24 August 2023
+* Add flag to mitigate duplicate security role names (@mkholt)
+
 ### 1.12.0 - 16 December 2022
 * Add support for RetrieveCurrentOrganization Request (@kato88)
 

--- a/src/MetadataGen/MetadataGenerator11/AssemblyInfo.fs
+++ b/src/MetadataGen/MetadataGenerator11/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.12.0")]
-[assembly: AssemblyFileVersion("1.12.0")]
+[assembly: AssemblyVersion("1.12.1")]
+[assembly: AssemblyFileVersion("1.12.1")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.12.0";
-        internal const System.String AssemblyFileVersion = "1.12.0";
+        internal const System.String AssemblyVersion = "1.12.1";
+        internal const System.String AssemblyFileVersion = "1.12.1";
     }
 }

--- a/src/MetadataGen/MetadataGenerator13/AssemblyInfo.fs
+++ b/src/MetadataGen/MetadataGenerator13/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.12.0")]
-[assembly: AssemblyFileVersion("1.12.0")]
+[assembly: AssemblyVersion("1.12.1")]
+[assembly: AssemblyFileVersion("1.12.1")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.12.0";
-        internal const System.String AssemblyFileVersion = "1.12.0";
+        internal const System.String AssemblyVersion = "1.12.1";
+        internal const System.String AssemblyFileVersion = "1.12.1";
     }
 }

--- a/src/MetadataGen/MetadataGenerator15/AssemblyInfo.fs
+++ b/src/MetadataGen/MetadataGenerator15/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.12.0")]
-[assembly: AssemblyFileVersion("1.12.0")]
+[assembly: AssemblyVersion("1.12.1")]
+[assembly: AssemblyFileVersion("1.12.1")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.12.0";
-        internal const System.String AssemblyFileVersion = "1.12.0";
+        internal const System.String AssemblyVersion = "1.12.1";
+        internal const System.String AssemblyFileVersion = "1.12.1";
     }
 }

--- a/src/MetadataGen/MetadataGenerator16/AssemblyInfo.fs
+++ b/src/MetadataGen/MetadataGenerator16/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.12.0")]
-[assembly: AssemblyFileVersion("1.12.0")]
+[assembly: AssemblyVersion("1.12.1")]
+[assembly: AssemblyFileVersion("1.12.1")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.12.0";
-        internal const System.String AssemblyFileVersion = "1.12.0";
+        internal const System.String AssemblyVersion = "1.12.1";
+        internal const System.String AssemblyFileVersion = "1.12.1";
     }
 }

--- a/src/MetadataGen/MetadataGenerator365/AssemblyInfo.fs
+++ b/src/MetadataGen/MetadataGenerator365/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.12.0")]
-[assembly: AssemblyFileVersion("1.12.0")]
+[assembly: AssemblyVersion("1.12.1")]
+[assembly: AssemblyFileVersion("1.12.1")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.12.0";
-        internal const System.String AssemblyFileVersion = "1.12.0";
+        internal const System.String AssemblyVersion = "1.12.1";
+        internal const System.String AssemblyFileVersion = "1.12.1";
     }
 }

--- a/src/MetadataShared/Arguments.cs
+++ b/src/MetadataShared/Arguments.cs
@@ -98,6 +98,12 @@ namespace DG.Tools.XrmMockup.Metadata
             Abbreviations = new string[] { }
         };
 
+        public static ArgumentDescription MitigateDuplicateSecurityRoles = new ArgumentDescription()
+        {
+            Name = "mitigateDuplicateSecurityRoles",
+            Abbreviations = new string[] { }
+        };
+
         public static ArgumentDescription[] ArgList = new ArgumentDescription[] {
             Url,
             Username,
@@ -113,7 +119,8 @@ namespace DG.Tools.XrmMockup.Metadata
             ClientId,
             ReturnUrl,
             ClientSecret,
-            ConnectionString
+            ConnectionString,
+            MitigateDuplicateSecurityRoles
         };
     }
 }

--- a/src/MetadataShared/Program.cs
+++ b/src/MetadataShared/Program.cs
@@ -90,7 +90,9 @@ namespace DG.Tools.XrmMockup.Metadata {
                 }
             }
 
-            var securityRoles = generator.GetSecurityRoles(skeleton.RootBusinessUnit.Id);
+            var mitigateDuplicateSecurityRoles = ParsedArgs[Arguments.MitigateDuplicateSecurityRoles] != null;
+            var securityRoles = generator.GetSecurityRoles(skeleton.RootBusinessUnit.Id, mitigateDuplicateSecurityRoles);
+
             foreach (var securityRole in securityRoles) {
                 var safeName = ToSafeName(securityRole.Value.Name);
                 using (var stream = new FileStream($"{securityLocation}/{safeName}.xml", FileMode.Create)) {

--- a/src/XrmMockup2011/AssemblyInfo.fs
+++ b/src/XrmMockup2011/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.12.0")]
-[assembly: AssemblyFileVersion("1.12.0")]
+[assembly: AssemblyVersion("1.12.1")]
+[assembly: AssemblyFileVersion("1.12.1")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.12.0";
-        internal const System.String AssemblyFileVersion = "1.12.0";
+        internal const System.String AssemblyVersion = "1.12.1";
+        internal const System.String AssemblyFileVersion = "1.12.1";
     }
 }

--- a/src/XrmMockup2013/AssemblyInfo.fs
+++ b/src/XrmMockup2013/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.12.0")]
-[assembly: AssemblyFileVersion("1.12.0")]
+[assembly: AssemblyVersion("1.12.1")]
+[assembly: AssemblyFileVersion("1.12.1")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.12.0";
-        internal const System.String AssemblyFileVersion = "1.12.0";
+        internal const System.String AssemblyVersion = "1.12.1";
+        internal const System.String AssemblyFileVersion = "1.12.1";
     }
 }

--- a/src/XrmMockup2015/AssemblyInfo.fs
+++ b/src/XrmMockup2015/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.12.0")]
-[assembly: AssemblyFileVersion("1.12.0")]
+[assembly: AssemblyVersion("1.12.1")]
+[assembly: AssemblyFileVersion("1.12.1")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.12.0";
-        internal const System.String AssemblyFileVersion = "1.12.0";
+        internal const System.String AssemblyVersion = "1.12.1";
+        internal const System.String AssemblyFileVersion = "1.12.1";
     }
 }

--- a/src/XrmMockup2016/AssemblyInfo.fs
+++ b/src/XrmMockup2016/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.12.0")]
-[assembly: AssemblyFileVersion("1.12.0")]
+[assembly: AssemblyVersion("1.12.1")]
+[assembly: AssemblyFileVersion("1.12.1")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.12.0";
-        internal const System.String AssemblyFileVersion = "1.12.0";
+        internal const System.String AssemblyVersion = "1.12.1";
+        internal const System.String AssemblyFileVersion = "1.12.1";
     }
 }

--- a/src/XrmMockup365/AssemblyInfo.fs
+++ b/src/XrmMockup365/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.12.0")]
-[assembly: AssemblyFileVersion("1.12.0")]
+[assembly: AssemblyVersion("1.12.1")]
+[assembly: AssemblyFileVersion("1.12.1")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.12.0";
-        internal const System.String AssemblyFileVersion = "1.12.0";
+        internal const System.String AssemblyVersion = "1.12.1";
+        internal const System.String AssemblyFileVersion = "1.12.1";
     }
 }


### PR DESCRIPTION
… a counter to the name if a duplicate is detected.

A warning will be printed in console on activation.

The mitigation requires the flag "mitigateDuplicateSecurityRoles" to be passed to the program.

This fixes #225