### PR TITLE
Instantiate new instance based on existing metadata

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 1.12.3 - 22 December 2023
+* Add initializer based on an existing instance, letting us copy an already initialized XrmMockup instance (@mkholt)
+* Add timers during initialization (@mkholt)
+
 ### 1.12.2 - 24 August 2023
 * Add flag to mitigate duplicate security role names (@mkholt)
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,6 @@
 ### 1.12.3 - 22 December 2023
 * Add initializer based on an existing instance, letting us copy an already initialized XrmMockup instance (@mkholt)
+* Add optional tracing class factory to settings (@mkholt)
 * Add timers during initialization (@mkholt)
 
 ### 1.12.2 - 24 August 2023

--- a/src/MetadataGen/MetadataGenerator11/AssemblyInfo.fs
+++ b/src/MetadataGen/MetadataGenerator11/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.12.2")]
-[assembly: AssemblyFileVersion("1.12.2")]
+[assembly: AssemblyVersion("1.12.3")]
+[assembly: AssemblyFileVersion("1.12.3")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.12.2";
-        internal const System.String AssemblyFileVersion = "1.12.2";
+        internal const System.String AssemblyVersion = "1.12.3";
+        internal const System.String AssemblyFileVersion = "1.12.3";
     }
 }

--- a/src/MetadataGen/MetadataGenerator13/AssemblyInfo.fs
+++ b/src/MetadataGen/MetadataGenerator13/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.12.2")]
-[assembly: AssemblyFileVersion("1.12.2")]
+[assembly: AssemblyVersion("1.12.3")]
+[assembly: AssemblyFileVersion("1.12.3")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.12.2";
-        internal const System.String AssemblyFileVersion = "1.12.2";
+        internal const System.String AssemblyVersion = "1.12.3";
+        internal const System.String AssemblyFileVersion = "1.12.3";
     }
 }

--- a/src/MetadataGen/MetadataGenerator15/AssemblyInfo.fs
+++ b/src/MetadataGen/MetadataGenerator15/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.12.2")]
-[assembly: AssemblyFileVersion("1.12.2")]
+[assembly: AssemblyVersion("1.12.3")]
+[assembly: AssemblyFileVersion("1.12.3")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.12.2";
-        internal const System.String AssemblyFileVersion = "1.12.2";
+        internal const System.String AssemblyVersion = "1.12.3";
+        internal const System.String AssemblyFileVersion = "1.12.3";
     }
 }

--- a/src/MetadataGen/MetadataGenerator16/AssemblyInfo.fs
+++ b/src/MetadataGen/MetadataGenerator16/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.12.2")]
-[assembly: AssemblyFileVersion("1.12.2")]
+[assembly: AssemblyVersion("1.12.3")]
+[assembly: AssemblyFileVersion("1.12.3")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.12.2";
-        internal const System.String AssemblyFileVersion = "1.12.2";
+        internal const System.String AssemblyVersion = "1.12.3";
+        internal const System.String AssemblyFileVersion = "1.12.3";
     }
 }

--- a/src/MetadataGen/MetadataGenerator365/AssemblyInfo.fs
+++ b/src/MetadataGen/MetadataGenerator365/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.12.2")]
-[assembly: AssemblyFileVersion("1.12.2")]
+[assembly: AssemblyVersion("1.12.3")]
+[assembly: AssemblyFileVersion("1.12.3")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.12.2";
-        internal const System.String AssemblyFileVersion = "1.12.2";
+        internal const System.String AssemblyVersion = "1.12.3";
+        internal const System.String AssemblyFileVersion = "1.12.3";
     }
 }

--- a/src/XrmMockup2011/AssemblyInfo.fs
+++ b/src/XrmMockup2011/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.12.2")]
-[assembly: AssemblyFileVersion("1.12.2")]
+[assembly: AssemblyVersion("1.12.3")]
+[assembly: AssemblyFileVersion("1.12.3")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.12.2";
-        internal const System.String AssemblyFileVersion = "1.12.2";
+        internal const System.String AssemblyVersion = "1.12.3";
+        internal const System.String AssemblyFileVersion = "1.12.3";
     }
 }

--- a/src/XrmMockup2011/XrmMockup.cs
+++ b/src/XrmMockup2011/XrmMockup.cs
@@ -47,10 +47,14 @@ namespace DG.Tools.XrmMockup {
         /// <summary>
         /// Gets an instance of XrmMockup2011 using the same metadata as the provided
         /// </summary>
-        /// <param name="xrmMockup"></param>
-        public static XrmMockup2011 GetInstance(XrmMockup2011 xrmMockup)
+        /// <param name="xrmMockup">The existing instance to copy</param>
+        /// <param name="settings">
+        ///     If provided, will override the settings from the existing instance.<br/>
+        ///     <em>NOTE: Changing <see cref="XrmMockupSettings.MetadataDirectoryPath"/> will not trigger a reload</em>
+        /// </param>
+        public static XrmMockup2011 GetInstance(XrmMockup2011 xrmMockup, XrmMockupSettings settings = null)
         {
-            return new XrmMockup2011(xrmMockup.Settings, xrmMockup.Metadata, xrmMockup.Workflows, xrmMockup.SecurityRoles);
+            return new XrmMockup2011(settings ?? xrmMockup.Settings, xrmMockup.Metadata, xrmMockup.Workflows, xrmMockup.SecurityRoles);
         }
     }
 

--- a/src/XrmMockup2011/XrmMockup.cs
+++ b/src/XrmMockup2011/XrmMockup.cs
@@ -25,10 +25,11 @@ namespace DG.Tools.XrmMockup {
         private static Dictionary<XrmMockupSettings, XrmMockup2011> instances = new Dictionary<XrmMockupSettings, XrmMockup2011>();
 
 
-        private XrmMockup2011(XrmMockupSettings Settings) 
-            : base(Settings) {
+        private XrmMockup2011(XrmMockupSettings Settings, MetadataSkeleton metadata = null, List<Entity> workflows = null, List<SecurityRole> securityRoles = null) :
+            base(Settings, metadata, workflows, securityRoles)
+        {
         }
-        
+
         /// <summary>
         /// Gets an instance of XrmMockup2011
         /// </summary>
@@ -41,6 +42,15 @@ namespace DG.Tools.XrmMockup {
             var instance = new XrmMockup2011(Settings);
             instances[Settings] = instance;
             return instance;
+        }
+
+        /// <summary>
+        /// Gets an instance of XrmMockup2011 using the same metadata as the provided
+        /// </summary>
+        /// <param name="xrmMockup"></param>
+        public static XrmMockup2011 GetInstance(XrmMockup2011 xrmMockup)
+        {
+            return new XrmMockup2011(xrmMockup.Settings, xrmMockup.Metadata, xrmMockup.Workflows, xrmMockup.SecurityRoles);
         }
     }
 

--- a/src/XrmMockup2013/AssemblyInfo.fs
+++ b/src/XrmMockup2013/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.12.2")]
-[assembly: AssemblyFileVersion("1.12.2")]
+[assembly: AssemblyVersion("1.12.3")]
+[assembly: AssemblyFileVersion("1.12.3")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.12.2";
-        internal const System.String AssemblyFileVersion = "1.12.2";
+        internal const System.String AssemblyVersion = "1.12.3";
+        internal const System.String AssemblyFileVersion = "1.12.3";
     }
 }

--- a/src/XrmMockup2013/XrmMockup.cs
+++ b/src/XrmMockup2013/XrmMockup.cs
@@ -19,10 +19,11 @@ namespace DG.Tools.XrmMockup {
         private static Dictionary<XrmMockupSettings, XrmMockup2013> instances = new Dictionary<XrmMockupSettings, XrmMockup2013>();
 
 
-        private XrmMockup2013(XrmMockupSettings Settings) : 
-            base(Settings) {
+        private XrmMockup2013(XrmMockupSettings Settings, MetadataSkeleton metadata = null, List<Entity> workflows = null, List<SecurityRole> securityRoles = null) :
+            base(Settings, metadata, workflows, securityRoles)
+        {
         }
-        
+
         /// <summary>
         /// Gets an instance of XrmMockup2013
         /// </summary>
@@ -35,6 +36,15 @@ namespace DG.Tools.XrmMockup {
             var instance = new XrmMockup2013(Settings);
             instances[Settings] = instance;
             return instance;
+        }
+
+        /// <summary>
+        /// Gets an instance of XrmMockup2013 using the same metadata as the provided
+        /// </summary>
+        /// <param name="xrmMockup"></param>
+        public static XrmMockup2013 GetInstance(XrmMockup2013 xrmMockup)
+        {
+            return new XrmMockup2013(xrmMockup.Settings, xrmMockup.Metadata, xrmMockup.Workflows, xrmMockup.SecurityRoles);
         }
     }
 }

--- a/src/XrmMockup2013/XrmMockup.cs
+++ b/src/XrmMockup2013/XrmMockup.cs
@@ -41,10 +41,14 @@ namespace DG.Tools.XrmMockup {
         /// <summary>
         /// Gets an instance of XrmMockup2013 using the same metadata as the provided
         /// </summary>
-        /// <param name="xrmMockup"></param>
-        public static XrmMockup2013 GetInstance(XrmMockup2013 xrmMockup)
+        /// <param name="xrmMockup">The existing instance to copy</param>
+        /// <param name="settings">
+        ///     If provided, will override the settings from the existing instance.<br/>
+        ///     <em>NOTE: Changing <see cref="XrmMockupSettings.MetadataDirectoryPath"/> will not trigger a reload</em>
+        /// </param>
+        public static XrmMockup2013 GetInstance(XrmMockup2013 xrmMockup, XrmMockupSettings settings = null)
         {
-            return new XrmMockup2013(xrmMockup.Settings, xrmMockup.Metadata, xrmMockup.Workflows, xrmMockup.SecurityRoles);
+            return new XrmMockup2013(settings ?? xrmMockup.Settings, xrmMockup.Metadata, xrmMockup.Workflows, xrmMockup.SecurityRoles);
         }
     }
 }

--- a/src/XrmMockup2015/AssemblyInfo.fs
+++ b/src/XrmMockup2015/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.12.2")]
-[assembly: AssemblyFileVersion("1.12.2")]
+[assembly: AssemblyVersion("1.12.3")]
+[assembly: AssemblyFileVersion("1.12.3")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.12.2";
-        internal const System.String AssemblyFileVersion = "1.12.2";
+        internal const System.String AssemblyVersion = "1.12.3";
+        internal const System.String AssemblyFileVersion = "1.12.3";
     }
 }

--- a/src/XrmMockup2015/XrmMockup.cs
+++ b/src/XrmMockup2015/XrmMockup.cs
@@ -19,10 +19,11 @@ namespace DG.Tools.XrmMockup {
         private static Dictionary<XrmMockupSettings, XrmMockup2015> instances = new Dictionary<XrmMockupSettings, XrmMockup2015>();
 
 
-        private XrmMockup2015(XrmMockupSettings Settings) : 
-            base(Settings) {
+        private XrmMockup2015(XrmMockupSettings Settings, MetadataSkeleton metadata = null, List<Entity> workflows = null, List<SecurityRole> securityRoles = null) :
+            base(Settings, metadata, workflows, securityRoles)
+        {
         }
-        
+
         /// <summary>
         /// Gets an instance of XrmMockup2015
         /// </summary>
@@ -36,5 +37,14 @@ namespace DG.Tools.XrmMockup {
             instances[Settings] = instance;
             return instance;
         }
+        /// <summary>
+        /// Gets an instance of XrmMockup2015 using the same metadata as the provided
+        /// </summary>
+        /// <param name="xrmMockup"></param>
+        public static XrmMockup2015 GetInstance(XrmMockup2015 xrmMockup)
+        {
+            return new XrmMockup2015(xrmMockup.Settings, xrmMockup.Metadata, xrmMockup.Workflows, xrmMockup.SecurityRoles);
+        }
+
     }
 }

--- a/src/XrmMockup2015/XrmMockup.cs
+++ b/src/XrmMockup2015/XrmMockup.cs
@@ -16,7 +16,7 @@ namespace DG.Tools.XrmMockup {
     /// </summary>
     public class XrmMockup2015 : XrmMockupBase {
 
-        private static Dictionary<XrmMockupSettings, XrmMockup2015> instances = new Dictionary<XrmMockupSettings, XrmMockup2015>();
+        private static readonly Dictionary<XrmMockupSettings, XrmMockup2015> instances = new Dictionary<XrmMockupSettings, XrmMockup2015>();
 
 
         private XrmMockup2015(XrmMockupSettings Settings, MetadataSkeleton metadata = null, List<Entity> workflows = null, List<SecurityRole> securityRoles = null) :
@@ -37,14 +37,18 @@ namespace DG.Tools.XrmMockup {
             instances[Settings] = instance;
             return instance;
         }
+
         /// <summary>
         /// Gets an instance of XrmMockup2015 using the same metadata as the provided
         /// </summary>
-        /// <param name="xrmMockup"></param>
-        public static XrmMockup2015 GetInstance(XrmMockup2015 xrmMockup)
+        /// <param name="xrmMockup">The existing instance to copy</param>
+        /// <param name="settings">
+        ///     If provided, will override the settings from the existing instance.<br/>
+        ///     <em>NOTE: Changing <see cref="XrmMockupSettings.MetadataDirectoryPath"/> will not trigger a reload</em>
+        /// </param>
+        public static XrmMockup2015 GetInstance(XrmMockup2015 xrmMockup, XrmMockupSettings settings = null)
         {
-            return new XrmMockup2015(xrmMockup.Settings, xrmMockup.Metadata, xrmMockup.Workflows, xrmMockup.SecurityRoles);
+            return new XrmMockup2015(settings ?? xrmMockup.Settings, xrmMockup.Metadata, xrmMockup.Workflows, xrmMockup.SecurityRoles);
         }
-
     }
 }

--- a/src/XrmMockup2016/AssemblyInfo.fs
+++ b/src/XrmMockup2016/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.12.2")]
-[assembly: AssemblyFileVersion("1.12.2")]
+[assembly: AssemblyVersion("1.12.3")]
+[assembly: AssemblyFileVersion("1.12.3")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.12.2";
-        internal const System.String AssemblyFileVersion = "1.12.2";
+        internal const System.String AssemblyVersion = "1.12.3";
+        internal const System.String AssemblyFileVersion = "1.12.3";
     }
 }

--- a/src/XrmMockup2016/XrmMockup.cs
+++ b/src/XrmMockup2016/XrmMockup.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Microsoft.Xrm.Sdk;
+using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("XrmMockup16Test")]
@@ -12,10 +13,12 @@ namespace DG.Tools.XrmMockup {
         private static Dictionary<XrmMockupSettings, XrmMockup2016> instances = new Dictionary<XrmMockupSettings, XrmMockup2016>();
 
 
-        private XrmMockup2016(XrmMockupSettings Settings) : 
-            base(Settings) {}
+        private XrmMockup2016(XrmMockupSettings Settings, MetadataSkeleton metadata = null, List<Entity> workflows = null, List<SecurityRole> securityRoles = null) :
+            base(Settings, metadata, workflows, securityRoles)
+        {
+        }
 
-        
+
         /// <summary>
         /// Gets an instance of XrmMockup2016
         /// </summary>
@@ -27,6 +30,15 @@ namespace DG.Tools.XrmMockup {
             var instance = new XrmMockup2016(Settings);
             instances[Settings] = instance;
             return instance;
+        }
+
+        /// <summary>
+        /// Gets an instance of XrmMockup2016 using the same metadata as the provided
+        /// </summary>
+        /// <param name="xrmMockup"></param>
+        public static XrmMockup2016 GetInstance(XrmMockup2016 xrmMockup)
+        {
+            return new XrmMockup2016(xrmMockup.Settings, xrmMockup.Metadata, xrmMockup.Workflows, xrmMockup.SecurityRoles);
         }
     }
 }

--- a/src/XrmMockup2016/XrmMockup.cs
+++ b/src/XrmMockup2016/XrmMockup.cs
@@ -35,10 +35,14 @@ namespace DG.Tools.XrmMockup {
         /// <summary>
         /// Gets an instance of XrmMockup2016 using the same metadata as the provided
         /// </summary>
-        /// <param name="xrmMockup"></param>
-        public static XrmMockup2016 GetInstance(XrmMockup2016 xrmMockup)
+        /// <param name="xrmMockup">The existing instance to copy</param>
+        /// <param name="settings">
+        ///     If provided, will override the settings from the existing instance.<br/>
+        ///     <em>NOTE: Changing <see cref="XrmMockupSettings.MetadataDirectoryPath"/> will not trigger a reload</em>
+        /// </param>
+        public static XrmMockup2016 GetInstance(XrmMockup2016 xrmMockup, XrmMockupSettings settings = null)
         {
-            return new XrmMockup2016(xrmMockup.Settings, xrmMockup.Metadata, xrmMockup.Workflows, xrmMockup.SecurityRoles);
-        }
-    }
+            return new XrmMockup2016(settings ?? xrmMockup.Settings, xrmMockup.Metadata, xrmMockup.Workflows, xrmMockup.SecurityRoles);
+        } 
+     }
 }

--- a/src/XrmMockup365/AssemblyInfo.fs
+++ b/src/XrmMockup365/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.12.2")]
-[assembly: AssemblyFileVersion("1.12.2")]
+[assembly: AssemblyVersion("1.12.3")]
+[assembly: AssemblyFileVersion("1.12.3")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.12.2";
-        internal const System.String AssemblyFileVersion = "1.12.2";
+        internal const System.String AssemblyVersion = "1.12.3";
+        internal const System.String AssemblyFileVersion = "1.12.3";
     }
 }

--- a/src/XrmMockup365/XrmMockup.cs
+++ b/src/XrmMockup365/XrmMockup.cs
@@ -16,11 +16,11 @@ namespace DG.Tools.XrmMockup {
     /// </summary>
     public class XrmMockup365 : XrmMockupBase {
 
-        private static Dictionary<XrmMockupSettings, XrmMockup365> instances = new Dictionary<XrmMockupSettings, XrmMockup365>();
+        private static readonly Dictionary<XrmMockupSettings, XrmMockup365> instances = new Dictionary<XrmMockupSettings, XrmMockup365>();
 
-
-        private XrmMockup365(XrmMockupSettings Settings) : 
-            base(Settings) {
+        private XrmMockup365(XrmMockupSettings Settings, MetadataSkeleton metadata = null, List<Entity> workflows = null, List<SecurityRole> securityRoles = null) :
+            base(Settings, metadata, workflows, securityRoles)
+        {
         }
         
         /// <summary>
@@ -35,6 +35,15 @@ namespace DG.Tools.XrmMockup {
             var instance = new XrmMockup365(Settings);
             instances[Settings] = instance;
             return instance;
+        }
+
+        /// <summary>
+        /// Gets an instance of XrmMockup365 using the same metadata as the provided
+        /// </summary>
+        /// <param name="xrmMockup"></param>
+        public static XrmMockup365 GetInstance(XrmMockup365 xrmMockup)
+        {
+            return new XrmMockup365(xrmMockup.Settings, xrmMockup.Metadata, xrmMockup.Workflows, xrmMockup.SecurityRoles);
         }
     }
 }

--- a/src/XrmMockup365/XrmMockup.cs
+++ b/src/XrmMockup365/XrmMockup.cs
@@ -40,10 +40,14 @@ namespace DG.Tools.XrmMockup {
         /// <summary>
         /// Gets an instance of XrmMockup365 using the same metadata as the provided
         /// </summary>
-        /// <param name="xrmMockup"></param>
-        public static XrmMockup365 GetInstance(XrmMockup365 xrmMockup)
+        /// <param name="xrmMockup">The existing instance to copy</param>
+        /// <param name="settings">
+        ///     If provided, will override the settings from the existing instance.<br/>
+        ///     <em>NOTE: Changing <see cref="XrmMockupSettings.MetadataDirectoryPath"/> will not trigger a reload</em>
+        /// </param>
+        public static XrmMockup365 GetInstance(XrmMockup365 xrmMockup, XrmMockupSettings settings = null)
         {
-            return new XrmMockup365(xrmMockup.Settings, xrmMockup.Metadata, xrmMockup.Workflows, xrmMockup.SecurityRoles);
+            return new XrmMockup365(settings ?? xrmMockup.Settings, xrmMockup.Metadata, xrmMockup.Workflows, xrmMockup.SecurityRoles);
         }
     }
 }

--- a/src/XrmMockupShared/Core.cs
+++ b/src/XrmMockupShared/Core.cs
@@ -74,7 +74,7 @@ namespace DG.Tools.XrmMockup
         private int baseCurrencyPrecision;
         public TimeSpan TimeOffset { get; private set; }
         public MockupServiceProviderAndFactory ServiceFactory { get; }
-        public TracingServiceFactory TracingServiceFactory { get; }
+        public ITracingServiceFactory TracingServiceFactory { get; }
 
         private List<string> systemAttributeNames;
 
@@ -113,7 +113,7 @@ namespace DG.Tools.XrmMockup
             this.db = new XrmDb(metadata.EntityMetadata, GetOnlineProxy());
             this.snapshots = new Dictionary<string, Snapshot>();
             this.security = new Security(this, metadata, SecurityRoles,db);
-            this.TracingServiceFactory = new TracingServiceFactory(settings.TracingServiceFactory);
+            this.TracingServiceFactory = settings.TracingServiceFactory ?? new TracingServiceFactory();
             this.ServiceFactory = new MockupServiceProviderAndFactory(this);
 
             //add the additional plugin settings to the meta data

--- a/src/XrmMockupShared/Core.cs
+++ b/src/XrmMockupShared/Core.cs
@@ -74,6 +74,7 @@ namespace DG.Tools.XrmMockup
         private int baseCurrencyPrecision;
         public TimeSpan TimeOffset { get; private set; }
         public MockupServiceProviderAndFactory ServiceFactory { get; }
+        public TracingServiceFactory TracingServiceFactory { get; }
 
         private List<string> systemAttributeNames;
 
@@ -112,6 +113,7 @@ namespace DG.Tools.XrmMockup
             this.db = new XrmDb(metadata.EntityMetadata, GetOnlineProxy());
             this.snapshots = new Dictionary<string, Snapshot>();
             this.security = new Security(this, metadata, SecurityRoles,db);
+            this.TracingServiceFactory = new TracingServiceFactory(settings.TracingServiceFactory);
             this.ServiceFactory = new MockupServiceProviderAndFactory(this);
 
             //add the additional plugin settings to the meta data
@@ -1155,14 +1157,14 @@ namespace DG.Tools.XrmMockup
 
                 if (definition == null)
                 {
-                    var trace = this.ServiceFactory.GetService(typeof(ITracingService)) as ITracingService;
+                    var trace = this.ServiceFactory.GetService<ITracingService>();
                     trace.Trace($"Calculated field on {attr.EntityLogicalName} field {attr.LogicalName} is empty");
                     return;
                 }
                 var tree = WorkflowConstructor.ParseCalculated(definition);
                 var factory = this.ServiceFactory;
                 tree.Execute(row.ToEntity().CloneEntity(row.Metadata, new ColumnSet(true)), this.TimeOffset, this.GetWorkflowService(),
-                    factory, factory.GetService(typeof(ITracingService)) as ITracingService);
+                    factory, factory.GetService<ITracingService>());
             }
         }
 #endif

--- a/src/XrmMockupShared/MockupServiceProviderAndFactory.cs
+++ b/src/XrmMockupShared/MockupServiceProviderAndFactory.cs
@@ -24,12 +24,12 @@ namespace DG.Tools.XrmMockup {
         /// Creates new MockupServiceProviderAndFactory object
         /// </summary>
         /// <param name="core"></param>
-        public MockupServiceProviderAndFactory(Core core) : this(core, null, new TracingService()) { }
+        public MockupServiceProviderAndFactory(Core core) : this(core, null, core.TracingServiceFactory) { }
 
-        internal MockupServiceProviderAndFactory(Core core, PluginContext pluginContext, ITracingService tracingService) {
+        internal MockupServiceProviderAndFactory(Core core, PluginContext pluginContext, TracingServiceFactory tracingServiceFactory) {
             this.core = core;
             this.pluginContext = pluginContext;
-            this.tracingService = tracingService;
+            this.tracingService = tracingServiceFactory.GetService();
         }
 
         /// <summary>
@@ -42,6 +42,11 @@ namespace DG.Tools.XrmMockup {
             if (serviceType == typeof(ITracingService)) return this.tracingService;
             if (serviceType == typeof(IOrganizationServiceFactory)) return this;
             return null;
+        }
+
+        public TService GetService<TService>() where TService: class
+        {
+            return GetService(typeof(TService)) as TService;
         }
 
         public IOrganizationService CreateOrganizationService(Guid? userId)

--- a/src/XrmMockupShared/MockupServiceProviderAndFactory.cs
+++ b/src/XrmMockupShared/MockupServiceProviderAndFactory.cs
@@ -26,7 +26,7 @@ namespace DG.Tools.XrmMockup {
         /// <param name="core"></param>
         public MockupServiceProviderAndFactory(Core core) : this(core, null, core.TracingServiceFactory) { }
 
-        internal MockupServiceProviderAndFactory(Core core, PluginContext pluginContext, TracingServiceFactory tracingServiceFactory) {
+        internal MockupServiceProviderAndFactory(Core core, PluginContext pluginContext, ITracingServiceFactory tracingServiceFactory) {
             this.core = core;
             this.pluginContext = pluginContext;
             this.tracingService = tracingServiceFactory.GetService();

--- a/src/XrmMockupShared/Plugin/PluginManager.cs
+++ b/src/XrmMockupShared/Plugin/PluginManager.cs
@@ -378,7 +378,7 @@ namespace DG.Tools.XrmMockup
                 {
                     // Create the plugin context
                     var thisPluginContext = CreatePluginContext(pluginContext, guid, logicalName, preImage, postImage);
-                    return new PluginExecutionProvider(pluginExecute, new MockupServiceProviderAndFactory(core, thisPluginContext, new TracingService()));
+                    return new PluginExecutionProvider(pluginExecute, new MockupServiceProviderAndFactory(core, thisPluginContext, core.TracingServiceFactory));
                 }
 
                 return null;
@@ -398,7 +398,7 @@ namespace DG.Tools.XrmMockup
                     var thisPluginContext = CreatePluginContext(pluginContext, guid, logicalName, preImage, postImage);
 
                     //Create Serviceprovider, and execute plugin
-                    MockupServiceProviderAndFactory provider = new MockupServiceProviderAndFactory(core, thisPluginContext, new TracingService());
+                    MockupServiceProviderAndFactory provider = new MockupServiceProviderAndFactory(core, thisPluginContext, core.TracingServiceFactory);
                     try
                     {
                         pluginExecute(provider);

--- a/src/XrmMockupShared/Requests/CalculateRollupFieldRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/CalculateRollupFieldRequestHandler.cs
@@ -40,7 +40,7 @@ namespace DG.Tools.XrmMockup {
                 } else {
                     var tree = WorkflowConstructor.ParseRollUp(definition);
                     var factory = core.ServiceFactory;
-                    var resultTree = tree.Execute(dbEntity, core.TimeOffset, core.GetWorkflowService(), factory, factory.GetService(typeof(ITracingService)) as ITracingService);
+                    var resultTree = tree.Execute(dbEntity, core.TimeOffset, core.GetWorkflowService(), factory, factory.GetService<ITracingService>());
                     var resultLocaltion = ((resultTree.StartActivity as RollUp).Aggregation[1] as Aggregate).VariableName;
                     var result = resultTree.Variables[resultLocaltion];
                     if (result != null) {

--- a/src/XrmMockupShared/Requests/DeleteRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/DeleteRequestHandler.cs
@@ -59,7 +59,7 @@ namespace DG.Tools.XrmMockup {
                             }, userRef);
                             break;
                         case CascadeType.Restrict:
-                            var trace = core.ServiceFactory.GetService(typeof(ITracingService)) as ITracingService;
+                            var trace = core.ServiceFactory.GetService<ITracingService>();
                             trace.Trace($"Delete restricted for {relatedEntities.Key.SchemaName} when trying to delete {entity.LogicalName} with id {entity.Id}");
                             return new DeleteResponse();
                     }

--- a/src/XrmMockupShared/Requests/RetrieveMultipleRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/RetrieveMultipleRequestHandler.cs
@@ -40,8 +40,6 @@ namespace DG.Tools.XrmMockup {
             db.PrefillDBWithOnlineData(queryExpr);
             var rows = db.GetDBEntityRows(queryExpr.EntityName);
 
-            Console.WriteLine($"\t row count : {rows.Count().ToString()}");
-
             var entityMetadata = metadata.EntityMetadata[queryExpr.EntityName];
 
 #if !(XRM_MOCKUP_2011 || XRM_MOCKUP_2013)

--- a/src/XrmMockupShared/TracingService.cs
+++ b/src/XrmMockupShared/TracingService.cs
@@ -1,9 +1,12 @@
 ﻿using Microsoft.Xrm.Sdk;
 using System;
 
-namespace DG.Tools.XrmMockup {
-    internal sealed class TracingService : ITracingService {
-        public void Trace(string format, params object[] args) {
+namespace DG.Tools.XrmMockup
+{
+	internal sealed class TracingService : ITracingService
+	{
+		public void Trace(string format, params object[] args)
+		{
 			try
 			{
 				Console.WriteLine(format, args);
@@ -12,6 +15,6 @@ namespace DG.Tools.XrmMockup {
 			{
 				Console.WriteLine(format);
 			}
-        }
-    }
+		}
+	}
 }

--- a/src/XrmMockupShared/TracingService.cs
+++ b/src/XrmMockupShared/TracingService.cs
@@ -1,18 +1,14 @@
 ﻿using Microsoft.Xrm.Sdk;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace DG.Tools.XrmMockup {
-    internal class TracingService : ITracingService {
+    internal sealed class TracingService : ITracingService {
         public void Trace(string format, params object[] args) {
 			try
 			{
 				Console.WriteLine(format, args);
 			}
-			catch 
+			catch
 			{
 				Console.WriteLine(format);
 			}

--- a/src/XrmMockupShared/TracingServiceFactory.cs
+++ b/src/XrmMockupShared/TracingServiceFactory.cs
@@ -3,15 +3,13 @@ using System;
 
 namespace DG.Tools.XrmMockup
 {
-    internal class TracingServiceFactory
+    public interface ITracingServiceFactory
     {
-        private readonly Func<ITracingService> _factory;
+        ITracingService GetService();
+    }
 
-        public TracingServiceFactory(Func<ITracingService> factory)
-        {
-            _factory = factory;
-        }
-
-        public ITracingService GetService() => _factory?.Invoke() ?? new TracingService();
+    internal class TracingServiceFactory : ITracingServiceFactory
+    {
+        public ITracingService GetService() => new TracingService();
     }
 }

--- a/src/XrmMockupShared/TracingServiceFactory.cs
+++ b/src/XrmMockupShared/TracingServiceFactory.cs
@@ -1,0 +1,17 @@
+using Microsoft.Xrm.Sdk;
+using System;
+
+namespace DG.Tools.XrmMockup
+{
+    internal class TracingServiceFactory
+    {
+        private readonly Func<ITracingService> _factory;
+
+        public TracingServiceFactory(Func<ITracingService> factory)
+        {
+            _factory = factory;
+        }
+
+        public ITracingService GetService() => _factory?.Invoke() ?? new TracingService();
+    }
+}

--- a/src/XrmMockupShared/Workflow/WorkflowManager.cs
+++ b/src/XrmMockupShared/Workflow/WorkflowManager.cs
@@ -119,7 +119,7 @@ namespace DG.Tools.XrmMockup {
         }
 
         internal void ExecuteWaitingWorkflows(PluginContext pluginContext, Core core) {
-            var provider = new MockupServiceProviderAndFactory(core, pluginContext, new TracingService());
+            var provider = new MockupServiceProviderAndFactory(core, pluginContext, core.TracingServiceFactory);
             var service = provider.CreateOrganizationService(null, new MockupServiceSettings(true, true, MockupServiceSettings.Role.SDK));
             foreach (var waitInfo in waitingWorkflows.ToList()) {
                 waitingWorkflows.Remove(waitInfo);
@@ -128,7 +128,7 @@ namespace DG.Tools.XrmMockup {
 
                 var primaryEntity = shadowService.Retrieve(waitInfo.PrimaryEntity.LogicalName, waitInfo.PrimaryEntity.Id, new ColumnSet(true));
                 variables["InputEntities(\"primaryEntity\")"] = primaryEntity;
-                waitInfo.Element.Execute(waitInfo.ElementIndex, ref variables, core.TimeOffset, service, provider, new TracingService());
+                waitInfo.Element.Execute(waitInfo.ElementIndex, ref variables, core.TimeOffset, service, provider, provider.GetService<ITracingService>());
                 if (variables["Wait"] != null) {
                     waitingWorkflows.Add(variables["Wait"] as WaitInfo);
                 }
@@ -382,9 +382,9 @@ namespace DG.Tools.XrmMockup {
         }
 
         internal WorkflowTree ExecuteWorkflow(WorkflowTree workflow, Entity primaryEntity, PluginContext pluginContext, Core core) {
-            var provider = new MockupServiceProviderAndFactory(core, pluginContext, new TracingService());
+            var provider = new MockupServiceProviderAndFactory(core, pluginContext, core.TracingServiceFactory);
             var service = provider.CreateAdminOrganizationService(new MockupServiceSettings(true, true, MockupServiceSettings.Role.SDK));
-            return workflow.Execute(primaryEntity, core.TimeOffset, service, provider, provider.GetService(typeof(ITracingService)) as ITracingService);
+            return workflow.Execute(primaryEntity, core.TimeOffset, service, provider, provider.GetService<ITracingService>());
         }
 
         internal WorkflowTree ParseWorkflow(Entity workflow) {

--- a/src/XrmMockupShared/XrmMockupBase.cs
+++ b/src/XrmMockupShared/XrmMockupBase.cs
@@ -8,6 +8,8 @@ using Microsoft.Xrm.Sdk.Metadata;
 using Microsoft.Xrm.Sdk.Query;
 using Microsoft.Crm.Sdk.Messages;
 using System.IO;
+using System.Diagnostics;
+using System.Collections.ObjectModel;
 
 namespace DG.Tools.XrmMockup
 {
@@ -50,28 +52,50 @@ namespace DG.Tools.XrmMockup
         private Core Core;
         private MockupServiceProviderAndFactory ServiceFactory;
 
+        private readonly Dictionary<string, long> timers;
+        public IReadOnlyDictionary<string, long> Timers => new ReadOnlyDictionary<string, long>(timers);
+
+        protected XrmMockupSettings Settings { get; }
+        protected MetadataSkeleton Metadata { get; }
+        protected List<Entity> Workflows { get; }
+        protected List<SecurityRole> SecurityRoles { get; }
 
         /// <summary>
         /// Create a new XrmMockup instance
         /// </summary>
-        /// <param name="settings"></param>
-        protected XrmMockupBase(XrmMockupSettings settings) {
+        protected XrmMockupBase(XrmMockupSettings settings, MetadataSkeleton metadata = null, List<Entity> workflows = null, List<SecurityRole> securityRoles = null) {
+            timers = new Dictionary<string, long>();
+            Settings = settings;
 
-            var metadataDirectory = "../../Metadata/";
-            if (settings.MetadataDirectoryPath != null)
-                metadataDirectory = settings.MetadataDirectoryPath;
-            MetadataSkeleton metadata = Utility.GetMetadata(metadataDirectory);
+            Stopwatch stopwatch = Stopwatch.StartNew();
+            var metadataDirectory = settings.MetadataDirectoryPath ?? "../../Metadata/";
+            Metadata = metadata ?? Utility.GetMetadata(metadataDirectory);
+            timers[nameof(Utility.GetMetadata)] = stopwatch.ElapsedMilliseconds;
 
-            List<Entity> workflows = Utility.GetWorkflows(metadataDirectory);
-            List<SecurityRole> securityRoles = Utility.GetSecurityRoles(metadataDirectory);
+            stopwatch.Restart();
+            Workflows = workflows ?? Utility.GetWorkflows(metadataDirectory);
+            timers[nameof(Utility.GetWorkflows)] = stopwatch.ElapsedMilliseconds;
 
-            this.Core = new Core(settings, metadata, workflows, securityRoles);
-            this.ServiceFactory = new MockupServiceProviderAndFactory(this.Core);
+            stopwatch.Restart();
+            SecurityRoles = securityRoles ?? Utility.GetSecurityRoles(metadataDirectory);
+            timers[nameof(Utility.GetSecurityRoles)] = stopwatch.ElapsedMilliseconds;
+
+            stopwatch.Restart();
+            Core = new Core(settings, Metadata, Workflows, SecurityRoles);
+            timers[nameof(Core)] = stopwatch.ElapsedMilliseconds;
+
+            stopwatch.Restart();
+            ServiceFactory = new MockupServiceProviderAndFactory(Core);
+            timers[nameof(ServiceFactory)] = stopwatch.ElapsedMilliseconds;
+
             if (settings.EnableProxyTypes == true) {
+                stopwatch.Restart();
                 EnableProxyTypes();
+                timers[nameof(EnableProxyTypes)] = stopwatch.ElapsedMilliseconds;
             }
-        }
 
+            stopwatch.Stop();
+        }
 
         /// <summary>
         /// Enable early-bound types from the given context

--- a/src/XrmMockupShared/XrmMockupSettings.cs
+++ b/src/XrmMockupShared/XrmMockupSettings.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.Xrm.Sdk.Client;
-using Microsoft.Xrm.Sdk;
 using System;
 using System.Collections.Generic;
 #if !(XRM_MOCKUP_2011 || XRM_MOCKUP_2013)
@@ -64,7 +63,7 @@ namespace DG.Tools.XrmMockup
         /// <para>Optional factory for creating new instances of ITracingService.</para>
         /// <para>If not specified, uses the built-in <see cref="TracingService"/></para>
         /// </summary>
-        public Func<ITracingService> TracingServiceFactory { get; set; }
+        public ITracingServiceFactory TracingServiceFactory { get; set; }
 
 #if XRM_MOCKUP_365
         /// <summary>

--- a/src/XrmMockupShared/XrmMockupSettings.cs
+++ b/src/XrmMockupShared/XrmMockupSettings.cs
@@ -60,6 +60,12 @@ namespace DG.Tools.XrmMockup
         /// </summary>
         public MetaPlugin[] IPluginMetadata { get; set; }
 
+        /// <summary>
+        /// <para>Optional factory for creating new instances of ITracingService.</para>
+        /// <para>If not specified, uses the built-in <see cref="TracingService"/></para>
+        /// </summary>
+        public Func<ITracingService> TracingServiceFactory { get; set; }
+
 #if XRM_MOCKUP_365
         /// <summary>
         /// List of Extensions to XrmMockup. This can be used to extend XrmMockup functionality to a certain degree.

--- a/src/XrmMockupShared/XrmMockupShared.projitems
+++ b/src/XrmMockupShared/XrmMockupShared.projitems
@@ -80,6 +80,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\TableDTO.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\TableRowDTO.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TracingService.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TracingServiceFactory.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utility.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Workflow\WorkflowManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)XmlHandling.cs" />

--- a/tests/SharedTests/TestTracingService.cs
+++ b/tests/SharedTests/TestTracingService.cs
@@ -16,30 +16,5 @@ namespace DG.XrmMockupTest
             ITracingService trace = new TracingService();
             trace.Trace("cams_signatures : <head><style type=text/css>p,li{font-family: Arial,Helvetica,sans-serif;font-size: 11pt;}</style></head><body><p contenteditable=\"false\"><span style=\font - family: Arial; font - size: 11pt; \">By signing the Agreement Plan, the signatories are certifying, subject to the exceptions detailed below, both the completeness of the Agreement Plan and the agreed commitment between [CUSTOMER] and [DELIVERY AGENT].</span></p></body>");
         }
-
-        [Fact]
-        public void TracingServiceFactoryCallsInnerFactory()
-        {
-            ITracingService trace = new TracingService();
-            var factory = new TracingServiceFactory(() => trace);
-
-            var fromFactory = factory.GetService();
-            Assert.Equal(trace, fromFactory);
-
-            var fromFactory2 = factory.GetService();
-            Assert.Equal(fromFactory, fromFactory2);
-        }
-
-        [Fact]
-        public void TracingServiceFactoryUsesFallback()
-        {
-            var factory = new TracingServiceFactory(null);
-
-            var fromFactory = factory.GetService();
-            Assert.NotNull(fromFactory);
-
-            var fromFactory2 = factory.GetService();
-            Assert.NotEqual(fromFactory, fromFactory2);
-        }
     }
 }

--- a/tests/SharedTests/TestTracingService.cs
+++ b/tests/SharedTests/TestTracingService.cs
@@ -16,5 +16,30 @@ namespace DG.XrmMockupTest
             ITracingService trace = new TracingService();
             trace.Trace("cams_signatures : <head><style type=text/css>p,li{font-family: Arial,Helvetica,sans-serif;font-size: 11pt;}</style></head><body><p contenteditable=\"false\"><span style=\font - family: Arial; font - size: 11pt; \">By signing the Agreement Plan, the signatories are certifying, subject to the exceptions detailed below, both the completeness of the Agreement Plan and the agreed commitment between [CUSTOMER] and [DELIVERY AGENT].</span></p></body>");
         }
+
+        [Fact]
+        public void TracingServiceFactoryCallsInnerFactory()
+        {
+            ITracingService trace = new TracingService();
+            var factory = new TracingServiceFactory(() => trace);
+
+            var fromFactory = factory.GetService();
+            Assert.Equal(trace, fromFactory);
+
+            var fromFactory2 = factory.GetService();
+            Assert.Equal(fromFactory, fromFactory2);
+        }
+
+        [Fact]
+        public void TracingServiceFactoryUsesFallback()
+        {
+            var factory = new TracingServiceFactory(null);
+
+            var fromFactory = factory.GetService();
+            Assert.NotNull(fromFactory);
+
+            var fromFactory2 = factory.GetService();
+            Assert.NotEqual(fromFactory, fromFactory2);
+        }
     }
 }

--- a/tests/SharedTests/TestZipSnapshot.cs
+++ b/tests/SharedTests/TestZipSnapshot.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using DG.XrmFramework.BusinessDomain.ServiceContext;
 using DG.Tools.XrmMockup;
 using Xunit;
+using System.ServiceModel;
 
 namespace DG.XrmMockupTest
 {
@@ -26,14 +27,8 @@ namespace DG.XrmMockupTest
 
             crm.ResetEnvironment();
 
-            try
-            {
-                Contact.Retrieve(orgAdminService, contact.Id);
-            }
-            catch (Exception ex)
-            {
-                Assert.Equal(ex.Message, $"The record of type '{contact.LogicalName}' with id '{contact.Id}' does not exist. If you use hard-coded records from CRM, then make sure you create those records before retrieving them.");
-            }
+            var ex = Assert.Throws<FaultException>(() => Contact.Retrieve(orgAdminService, contact.Id));
+            Assert.Equal(ex.Message, $"The record of type '{contact.LogicalName}' with id '{contact.Id}' does not exist. If you use hard-coded records from CRM, then make sure you create those records before retrieving them.");
 
             crm.RestoreZipSnapshot("testfile");
 


### PR DESCRIPTION
Add functionality to instantiate a new XrmMockup instance based on an existing one.

This allows us to run multiple instances in parallel, withou having to fully load XrmMockup each time, significantly speeding up the initialization time and reducing file IO.