### PR TITLE
Clear waiting workflows on reset when all workflows included

### DIFF
--- a/src/XrmMockupShared/Core.cs
+++ b/src/XrmMockupShared/Core.cs
@@ -1121,10 +1121,7 @@ namespace DG.Tools.XrmMockup
         internal void ResetEnvironment()
         {
             this.TimeOffset = new TimeSpan();
-            if (settings.IncludeAllWorkflows == false)
-            {
-                workflowManager.ResetWorkflows();
-            }
+            workflowManager.ResetWorkflows(settings.IncludeAllWorkflows);
 
             pluginManager.ResetPlugins();
             this.db = new XrmDb(metadata.EntityMetadata, GetOnlineProxy());

--- a/src/XrmMockupShared/Workflow/WorkflowManager.cs
+++ b/src/XrmMockupShared/Workflow/WorkflowManager.cs
@@ -419,10 +419,13 @@ namespace DG.Tools.XrmMockup {
             return actions.FirstOrDefault(e => e.GetAttributeValue<string>("name") == requestName);
         }
 
-        internal void ResetWorkflows() {
-            synchronousWorkflows = new List<Entity>();
-            asynchronousWorkflows = new List<Entity>();
-            parsedWorkflows = new Dictionary<Guid, WorkflowTree>();
+        internal void ResetWorkflows(bool? IncludeAllWorkflows) {
+            if (IncludeAllWorkflows == false)
+            {
+                synchronousWorkflows = new List<Entity>();
+                asynchronousWorkflows = new List<Entity>();
+                parsedWorkflows = new Dictionary<Guid, WorkflowTree>();
+            }
             waitingWorkflows = new List<WaitInfo>();
         }
     }


### PR DESCRIPTION
Currently pending workflows are just hanging after a reset if they are all included. This will cause errors once the waiting workflow executes and tries to fetch records that no longer exist