### PR TITLE
Resolve incident fixes

### DIFF
--- a/src/XrmMockupShared/Requests/CloseIncidentRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/CloseIncidentRequestHandler.cs
@@ -1,9 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.Xrm.Sdk;
+﻿using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
-using Microsoft.Xrm.Sdk.Query;
 using System.Linq;
 using Microsoft.Crm.Sdk.Messages;
 using System.ServiceModel;
@@ -80,12 +76,6 @@ namespace DG.Tools.XrmMockup
                 throw new FaultException($"incident With Id = {incidentRef.Id} is allready cancelled and connot be closed");
             }
 
-            var setStaterequest = new SetStateRequest();
-            setStaterequest.EntityMoniker = incidentRef;
-            setStaterequest.State = new OptionSetValue(1);
-            setStaterequest.Status = request.Status;
-            core.Execute(setStaterequest, userRef);
-
             var incidentResolution = db.GetDbRowOrNull(request.IncidentResolution.ToEntityReference());
 
             if (incidentResolution != null)
@@ -95,6 +85,17 @@ namespace DG.Tools.XrmMockup
 
             db.Add(request.IncidentResolution);
 
+            incident["statecode"] = new OptionSetValue(1);
+            incident["statuscode"] = request.Status;
+
+            var updateRequest = new UpdateRequest
+            {
+                Target = incident,
+                ["CloseIncidentRequestHandler"] = true,
+            };
+
+            core.Execute(updateRequest, userRef);
+            
             return new CloseIncidentResponse();
         }
     }

--- a/src/XrmMockupShared/Requests/UpdateRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/UpdateRequestHandler.cs
@@ -70,10 +70,16 @@ namespace DG.Tools.XrmMockup
         internal override OrganizationResponse Execute(OrganizationRequest orgRequest, EntityReference userRef)
         {
             var request = MakeRequest<UpdateRequest>(orgRequest);
-            var settings = MockupExecutionContext.GetSettings(request);
 
+            if (request.Target.LogicalName is "incident" &&
+                request.Target.GetAttributeValue<OptionSetValue>("statecode").Value is 1 &&
+                !request.Parameters.ContainsKey("CloseIncidentRequestHandler"))
+            {
+                throw new FaultException("This message can not be used to set the state of incident to Resolved. In order to set state of incident to Resolved, use the CloseIncidentRequest message instead.");
+            }
+            
+            var settings = MockupExecutionContext.GetSettings(request);
             var entRef = request.Target.ToEntityReferenceWithKeyAttributes();
-            var entity = request.Target;
             var row = db.GetDbRow(entRef);
 
             if (settings.ServiceRole == MockupServiceSettings.Role.UI &&

--- a/src/XrmMockupShared/Requests/UpdateRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/UpdateRequestHandler.cs
@@ -70,6 +70,7 @@ namespace DG.Tools.XrmMockup
         internal override OrganizationResponse Execute(OrganizationRequest orgRequest, EntityReference userRef)
         {
             var request = MakeRequest<UpdateRequest>(orgRequest);
+            var settings = MockupExecutionContext.GetSettings(request);
 
             if (request.Target.LogicalName is "incident" &&
                 request.Target.GetAttributeValue<OptionSetValue>("statecode").Value is 1 &&
@@ -78,7 +79,6 @@ namespace DG.Tools.XrmMockup
                 throw new FaultException("This message can not be used to set the state of incident to Resolved. In order to set state of incident to Resolved, use the CloseIncidentRequest message instead.");
             }
             
-            var settings = MockupExecutionContext.GetSettings(request);
             var entRef = request.Target.ToEntityReferenceWithKeyAttributes();
             var row = db.GetDbRow(entRef);
 

--- a/tests/SharedPluginsAndCodeactivites/IncidentDeleteAllRelatedResolutionsOnClose.cs
+++ b/tests/SharedPluginsAndCodeactivites/IncidentDeleteAllRelatedResolutionsOnClose.cs
@@ -1,0 +1,39 @@
+﻿using DG.XrmFramework.BusinessDomain.ServiceContext;
+using System.Linq;
+
+namespace DG.Some.Namespace
+{
+    public class IncidentDeleteAllRelatedResolutionsOnClose : Plugin
+    {
+        public IncidentDeleteAllRelatedResolutionsOnClose() : base(typeof(IncidentDeleteAllRelatedResolutionsOnClose))
+        {
+            RegisterPluginStep<Incident>(
+                EventOperation.Update,
+                ExecutionStage.PostOperation,
+                ExecuteDeleteAllRelatedResolutionsOnClose)
+                .AddFilteredAttributes(x => x.StateCode)
+                .AddImage(ImageType.PreImage, x => x.StateCode, x => x.Title)
+                .AddImage(ImageType.PostImage, x => x.StateCode)
+                .SetExecutionOrder(10);
+        }
+
+        protected void ExecuteDeleteAllRelatedResolutionsOnClose(LocalPluginContext localContext)
+        {
+            var preImage = localContext.PluginExecutionContext.PreEntityImages["PreImage"].ToEntity<Incident>();
+            if (preImage.Title != "TestRemovalOfResolutionsAfterClose") return;
+
+            var postImage = localContext.PluginExecutionContext.PostEntityImages["PostImage"].ToEntity<Incident>();
+
+            if (preImage.StateCode == IncidentState.Active && postImage.StateCode != IncidentState.Active)
+            {
+                using (var context = new Xrm(localContext.OrganizationService))
+                {
+                    context.IncidentResolutionSet
+                        .Where(x => x.IncidentId.Id == localContext.PluginExecutionContext.PrimaryEntityId)
+                        .ToList()
+                        .ForEach(x => localContext.OrganizationAdminService.Delete(x.LogicalName, x.Id));
+                }
+            }
+        }
+    }
+}

--- a/tests/SharedPluginsAndCodeactivites/SharedPluginsAndCodeactivites.projitems
+++ b/tests/SharedPluginsAndCodeactivites/SharedPluginsAndCodeactivites.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Closeincidentplugin.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)IncidentDeleteAllRelatedResolutionsOnClose.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ParentPostCreatePlugin.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ChildPreCreatePlugin.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NotePostOperationPlugin.cs" />


### PR DESCRIPTION
Fixes #208 
In `CloseIncidentRequestHandler` use `UpdateRequest` instead of `SetStateRequest`

Fixes #93 
In `UpdateRequestHandler` check if the target entity is an Incident whose state is Resolved. If yes, throw a FaultException.
Introduce custom parameter `CloseIncidentRequestHandler` to detect if the call was made from that particular handler. If yes, then ignore the check and update the incident as resolved.