### PR TITLE
Retrieve and RetrieveMultiple fixes

### DIFF
--- a/src/XrmMockupShared/Core.cs
+++ b/src/XrmMockupShared/Core.cs
@@ -673,6 +673,10 @@ namespace DG.Tools.XrmMockup
                     pluginContext.OutputParameters["BusinessEntityCollection"] =
                         (response as RetrieveMultipleResponse)?.EntityCollection;
                 }
+                else if (request is RetrieveRequest)
+                {
+                    pluginContext.OutputParameters["BusinessEntity"] = TryRetrieve((request as RetrieveRequest).Target);
+                }
 
                 if (!string.IsNullOrEmpty(eventOp))
                 {

--- a/src/XrmMockupShared/Mappings.cs
+++ b/src/XrmMockupShared/Mappings.cs
@@ -24,6 +24,7 @@ namespace DG.Tools.XrmMockup {
             { typeof(UpdateRequest), "Target" },
             { typeof(AssociateRequest), "Target" },
             { typeof(DisassociateRequest), "Target" },
+            { typeof(RetrieveRequest), "Target" },
         };
 
         public static Dictionary<Type, string> RequestToEventOperation = new Dictionary<Type, string>()

--- a/src/XrmMockupShared/Requests/RetrieveMultipleRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/RetrieveMultipleRequestHandler.cs
@@ -157,6 +157,12 @@ namespace DG.Tools.XrmMockup {
                 colToReturn = new EntityCollection(collection.Select(x=>x.Value).ToList());
             }
 
+            if (queryExpr.Distinct)
+            {
+                var uniqueIds = new HashSet<Guid>();
+                colToReturn = new EntityCollection(colToReturn.Entities.Where(entity => uniqueIds.Add(entity.Id)).ToList());
+            }
+
             // According to docs, should return -1 if ReturnTotalRecordCount set to false
             colToReturn.TotalRecordCount = queryExpr.PageInfo.ReturnTotalRecordCount ? colToReturn.Entities.Count : -1;
 

--- a/tests/SharedPluginsAndCodeactivites/RetrievePlugin.cs
+++ b/tests/SharedPluginsAndCodeactivites/RetrievePlugin.cs
@@ -1,0 +1,26 @@
+﻿using DG.XrmFramework.BusinessDomain.ServiceContext;
+using Microsoft.Xrm.Sdk;
+
+
+namespace DG.Some.Namespace
+{
+    public class RetrievePlugin : Plugin
+    {
+        public RetrievePlugin() : base(typeof(RetrievePlugin))
+        {
+            RegisterPluginStep<Account>(
+                EventOperation.Retrieve,
+                ExecutionStage.PostOperation,
+                Execute);
+        }
+
+        protected void Execute(LocalPluginContext localContext)
+        {
+            var entity = localContext.PluginExecutionContext.OutputParameters["BusinessEntity"] as Entity;
+            if (entity.ToEntity<Account>().StateCode == AccountState.Inactive)
+            {
+                throw new InvalidPluginExecutionException("Inactive accounts cannot be retrieved.");
+            }
+        }
+    }
+}

--- a/tests/SharedPluginsAndCodeactivites/RetrievePlugin.cs
+++ b/tests/SharedPluginsAndCodeactivites/RetrievePlugin.cs
@@ -8,18 +8,19 @@ namespace DG.Some.Namespace
     {
         public RetrievePlugin() : base(typeof(RetrievePlugin))
         {
-            RegisterPluginStep<Account>(
+            RegisterPluginStep<Contact>(
                 EventOperation.Retrieve,
                 ExecutionStage.PostOperation,
-                Execute);
+                ExecutePostRetrieve);
         }
 
-        protected void Execute(LocalPluginContext localContext)
+        protected void ExecutePostRetrieve(LocalPluginContext localContext)
         {
             var entity = localContext.PluginExecutionContext.OutputParameters["BusinessEntity"] as Entity;
-            if (entity.ToEntity<Account>().StateCode == AccountState.Inactive)
+
+            if (entity.ToEntity<Contact>().StateCode == ContactState.Inactive)
             {
-                throw new InvalidPluginExecutionException("Inactive accounts cannot be retrieved.");
+                throw new InvalidPluginExecutionException("Inactive contacts cannot be retrieved.");
             }
         }
     }

--- a/tests/SharedPluginsAndCodeactivites/SharedPluginsAndCodeactivites.projitems
+++ b/tests/SharedPluginsAndCodeactivites/SharedPluginsAndCodeactivites.projitems
@@ -17,6 +17,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)AccountCustomActivity.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)AccountBothImagePlugin.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FaxPreOperationPlugin.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RetrievePlugin.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UpdateIdInCreatePlugin.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ContactPostPlugin.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DirectPlugins\ContactIPluginDirectPostOp.cs" />

--- a/tests/SharedTests/TestRetrieve.cs
+++ b/tests/SharedTests/TestRetrieve.cs
@@ -305,15 +305,15 @@ namespace DG.XrmMockupTest
         [Fact]
         public void TestRetrievePlugin()
         {
-            var accountId = orgAdminUIService.Create(new Account());
+            var accountId = orgAdminService.Create(new Contact { LastName = "Test" });
 
-            orgAdminUIService.Update(new Account(accountId)
+            orgAdminUIService.Update(new Contact(accountId)
             {
-                StateCode = AccountState.Inactive,
-                StatusCode = Account_StatusCode.Inactive
+                StateCode = ContactState.Inactive,
+                StatusCode = Contact_StatusCode.Inactive
             });
 
-            Assert.Throws<InvalidPluginExecutionException>(() => orgAdminService.Retrieve(Account.EntityLogicalName, accountId, new ColumnSet(true)));
+            Assert.Throws<InvalidPluginExecutionException>(() => Contact.Retrieve(orgAdminService, accountId, x => x.LastName));
         }
     }
 }

--- a/tests/SharedTests/TestRetrieve.cs
+++ b/tests/SharedTests/TestRetrieve.cs
@@ -301,5 +301,19 @@ namespace DG.XrmMockupTest
             var users = orgAdminService.RetrieveMultiple(q);
             Assert.Single(users.Entities);
         }
+
+        [Fact]
+        public void TestRetrievePlugin()
+        {
+            var accountId = orgAdminUIService.Create(new Account());
+
+            orgAdminUIService.Update(new Account(accountId)
+            {
+                StateCode = AccountState.Inactive,
+                StatusCode = Account_StatusCode.Inactive
+            });
+
+            Assert.Throws<InvalidPluginExecutionException>(() => orgAdminService.Retrieve(Account.EntityLogicalName, accountId, new ColumnSet(true)));
+        }
     }
 }

--- a/tests/SharedTests/TestRetrieveMultiple.cs
+++ b/tests/SharedTests/TestRetrieveMultiple.cs
@@ -921,5 +921,16 @@ namespace DG.XrmMockupTest
 
             Assert.Equal("MATT", res.Entities.Single().GetAttributeValue<string>("firstname"));
         }
+
+        [Fact]
+        public void TestRetrieveMultipleFailWithNonExistentAttribute()
+        {
+            var query = new QueryExpression("contact")
+            {
+                ColumnSet = new ColumnSet("x")
+            };
+
+            Assert.Throws<AggregateException>(() => orgAdminService.RetrieveMultiple(query));
+        }
     }
 }

--- a/tests/SharedTests/TestRetrieveMultiple.cs
+++ b/tests/SharedTests/TestRetrieveMultiple.cs
@@ -773,6 +773,44 @@ namespace DG.XrmMockupTest
             Assert.Equal(2, res.Count());
         }
 
+        [Fact]
+        public void RetrieveMultipleWithLinkEntitiesReturnDistinctResults()
+        {
+            var lead = new Lead()
+            {
+                Subject = "Lead",
+                ParentContactId = contact1.ToEntityReference()
+            };
+            orgAdminService.Create(lead);
+
+            var linkEntity = new LinkEntity
+            {
+                LinkToEntityName = "lead",
+                LinkToAttributeName = "parentcontactid",
+                LinkFromEntityName = "contact",
+                LinkFromAttributeName = "contactid",
+                Columns = new ColumnSet(false),
+                EntityAlias = "contact",
+                JoinOperator = JoinOperator.LeftOuter,
+            };
+
+            var filter = new FilterExpression(LogicalOperator.And);
+            filter.AddCondition(new ConditionExpression("lastname", ConditionOperator.Equal, contact1.LastName));
+
+            var query = new QueryExpression("contact")
+            {
+                Distinct = true,
+                ColumnSet = new ColumnSet(),
+                LinkEntities = { linkEntity }
+            };
+
+            var res = orgAdminService.RetrieveMultiple(query).Entities;
+            
+            var distinctIdCount = res.Select(x => x.Id).Distinct().Count();
+
+            Assert.Equal(distinctIdCount, res.Count);
+        }
+
 #endif
 
         [Fact]


### PR DESCRIPTION
Fixes #227 
Add support for Retrieve plugins

Fixes #230 
Extend RetrieveMultipleRequestHandler to support `Distinct` specifications in `QueryExpressions`

Closes #203 
Add a unit test to research this issue. It seems to be solved. At least the RetrieveMultiple request throws an AggregateException, because the attribute failure happens within a Parallel.forEach loop.