### PR TITLE
Add file block upload handlers

### DIFF
--- a/src/MetadataShared/DataHelper.cs
+++ b/src/MetadataShared/DataHelper.cs
@@ -36,7 +36,7 @@ namespace DG.Tools.XrmMockup.Metadata
                 this.EntityLogicalNames = GetLogicalNames(AssemblyGetter.GetAssembliesInBuildPath());
 
             // Add default entities
-            var defaultEntities = new string[] { "businessunit", "systemuser", "transactioncurrency", "role", "systemuserroles", "team", "teamroles", "activitypointer", "roletemplate" };
+            var defaultEntities = new string[] { "businessunit", "systemuser", "transactioncurrency", "role", "systemuserroles", "team", "teamroles", "activitypointer", "roletemplate", "fileattachment" };
             foreach (var logicalName in defaultEntities)
             {
                 this.EntityLogicalNames.Add(logicalName);

--- a/src/XrmMockupShared/Core.cs
+++ b/src/XrmMockupShared/Core.cs
@@ -112,7 +112,7 @@ namespace DG.Tools.XrmMockup
 
             this.db = new XrmDb(metadata.EntityMetadata, GetOnlineProxy());
             this.snapshots = new Dictionary<string, Snapshot>();
-            this.security = new Security(this, metadata, SecurityRoles,db);
+            this.security = new Security(this, metadata, SecurityRoles, db);
             this.TracingServiceFactory = settings.TracingServiceFactory ?? new TracingServiceFactory();
             this.ServiceFactory = new MockupServiceProviderAndFactory(this);
 
@@ -131,7 +131,7 @@ namespace DG.Tools.XrmMockup
             this.RequestHandlers = GetRequestHandlers(db);
             InitializeDB();
             this.security.InitializeSecurityRoles(db);
-            
+
 #if !(XRM_MOCKUP_2011 || XRM_MOCKUP_2013)
             this.orgDetail = settings.OrganizationDetail;
 #endif
@@ -216,8 +216,8 @@ namespace DG.Tools.XrmMockup
             new CalculateRollupFieldRequestHandler(this, db, metadata, security),
 #endif
 #if !(XRM_MOCKUP_2011)
-                new AddUserToRecordTeamRequestHandler(this, db, metadata, security),
-                new RemoveUserFromRecordTeamRequestHandler(this, db, metadata, security),
+            new AddUserToRecordTeamRequestHandler(this, db, metadata, security),
+            new RemoveUserFromRecordTeamRequestHandler(this, db, metadata, security),
 #endif
             
 #if !(XRM_MOCKUP_2011 || XRM_MOCKUP_2013)
@@ -227,10 +227,16 @@ namespace DG.Tools.XrmMockup
 #if !(XRM_MOCKUP_2011 || XRM_MOCKUP_2013 || XRM_MOCKUP_2015)
             new UpsertRequestHandler(this, db, metadata, security),
 #endif
-                new RetrieveAttributeRequestHandler(this, db, metadata, security),
-                new WhoAmIRequestHandler(this, db, metadata, security),
-                new RetrievePrincipalAccessRequestHandler(this, db, metadata, security),
-                new RetrieveMetadataChangesRequestHandler(this, db, metadata, security)
+            new RetrieveAttributeRequestHandler(this, db, metadata, security),
+            new WhoAmIRequestHandler(this, db, metadata, security),
+            new RetrievePrincipalAccessRequestHandler(this, db, metadata, security),
+            new RetrieveMetadataChangesRequestHandler(this, db, metadata, security),
+
+#if !(XRM_MOCKUP_2011 || XRM_MOCKUP_2013 || XRM_MOCKUP_2015 || XRM_MOCKUP_2016)
+            new InitializeFileBlocksUploadRequestHandler(this, db, metadata, security),
+            new UploadBlockRequestHandler(this, db, metadata, security),
+            new CommitFileBlocksUploadRequestHandler(this, db, metadata, security),
+#endif
         };
 
         internal void EnableProxyTypes(Assembly assembly)
@@ -963,7 +969,7 @@ namespace DG.Tools.XrmMockup
             return resp;
         }
 
-#region EntityImage helpers
+        #region EntityImage helpers
 
         private Tuple<object, string, Guid> GetEntityInfo(OrganizationRequest request)
         {
@@ -1037,7 +1043,7 @@ namespace DG.Tools.XrmMockup
         {
             return Utility.GetBusinessUnit(db, owner);
         }
-#endregion
+        #endregion
 
         internal void DisabelRegisteredPlugins(bool include)
         {
@@ -1138,7 +1144,7 @@ namespace DG.Tools.XrmMockup
             return metadata.EntityMetadata[entityLogicalName];
         }
 
-      #if !(XRM_MOCKUP_2011 || XRM_MOCKUP_2013)
+#if !(XRM_MOCKUP_2011 || XRM_MOCKUP_2013)
         internal void ExecuteCalculatedFields(DbRow row)
         {
             var attributes = row.Metadata.Attributes.Where(

--- a/src/XrmMockupShared/Requests/CommitFileBlocksUploadRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/CommitFileBlocksUploadRequestHandler.cs
@@ -1,0 +1,25 @@
+﻿#if !(XRM_MOCKUP_2011 || XRM_MOCKUP_2013 || XRM_MOCKUP_2015 || XRM_MOCKUP_2016)
+
+using Microsoft.Xrm.Sdk;
+using Microsoft.Crm.Sdk.Messages;
+using DG.Tools.XrmMockup.Database;
+using System;
+using System.Linq;
+
+namespace DG.Tools.XrmMockup
+{
+    internal class CommitFileBlocksUploadRequestHandler : RequestHandler {
+        internal CommitFileBlocksUploadRequestHandler(Core core, XrmDb db, MetadataSkeleton metadata, Security security) : base(core, db, metadata, security, "CommitFileBlocksUpload") {}
+
+        internal override OrganizationResponse Execute(OrganizationRequest orgRequest, EntityReference userRef) {
+            var request = MakeRequest<CommitFileBlocksUploadRequest>(orgRequest);
+            
+            // Document store not implemented in database yet
+
+            var resp = new UploadBlockResponse();
+            return resp;
+        }
+    }
+}
+
+#endif

--- a/src/XrmMockupShared/Requests/InitializeFileBlocksUploadRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/InitializeFileBlocksUploadRequestHandler.cs
@@ -1,0 +1,31 @@
+﻿#if !(XRM_MOCKUP_2011 || XRM_MOCKUP_2013 || XRM_MOCKUP_2015 || XRM_MOCKUP_2016)
+
+using Microsoft.Xrm.Sdk;
+using Microsoft.Crm.Sdk.Messages;
+using DG.Tools.XrmMockup.Database;
+using System;
+using System.Linq;
+
+namespace DG.Tools.XrmMockup
+{
+    internal class InitializeFileBlocksUploadRequestHandler : RequestHandler {
+        internal InitializeFileBlocksUploadRequestHandler(Core core, XrmDb db, MetadataSkeleton metadata, Security security) : base(core, db, metadata, security, "InitializeFileBlocksUpload") {}
+
+        internal override OrganizationResponse Execute(OrganizationRequest orgRequest, EntityReference userRef) {
+            var request = MakeRequest<InitializeFileBlocksUploadRequest>(orgRequest);
+
+            var fileAttachment = new Entity("fileattachment");
+            fileAttachment["filename"] = request.FileName;
+            fileAttachment["regardingfieldname"] = request.FileAttributeName;
+            fileAttachment["objectid"] = request.Target;
+            db.Add(fileAttachment);
+
+
+            var resp = new InitializeFileBlocksUploadResponse();
+            resp.Results["FileContinuationToken"] = Guid.NewGuid().ToString();
+            return resp;
+        }
+    }
+}
+
+#endif

--- a/src/XrmMockupShared/Requests/UploadBlockRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/UploadBlockRequestHandler.cs
@@ -1,0 +1,25 @@
+﻿#if !(XRM_MOCKUP_2011 || XRM_MOCKUP_2013 || XRM_MOCKUP_2015 || XRM_MOCKUP_2016)
+
+using Microsoft.Xrm.Sdk;
+using Microsoft.Crm.Sdk.Messages;
+using DG.Tools.XrmMockup.Database;
+using System;
+using System.Linq;
+
+namespace DG.Tools.XrmMockup
+{
+    internal class UploadBlockRequestHandler : RequestHandler {
+        internal UploadBlockRequestHandler(Core core, XrmDb db, MetadataSkeleton metadata, Security security) : base(core, db, metadata, security, "UploadBlock") {}
+
+        internal override OrganizationResponse Execute(OrganizationRequest orgRequest, EntityReference userRef) {
+            var request = MakeRequest<UploadBlockRequest>(orgRequest);
+            
+            // Document store not implemented in database yet
+
+            var resp = new UploadBlockResponse();
+            return resp;
+        }
+    }
+}
+
+#endif

--- a/src/XrmMockupShared/XrmMockupShared.projitems
+++ b/src/XrmMockupShared/XrmMockupShared.projitems
@@ -14,6 +14,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Database\DbTable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MockupServiceAsync2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MockupServiceAsync.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Requests\CommitFileBlocksUploadRequestHandler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Requests\UploadBlockRequestHandler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Requests\InitializeFileBlocksUploadRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\DbDTO.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\OptionSetCollectionDTO.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\EntityReferenceDTO.cs" />


### PR DESCRIPTION
Adds boilerplate support for the three requiests

"InitializeFileBlocksUpload",
"UploadBlockRequest",
"CommitFileBlocksUploadRequest"

No file store implemented, but works for barebone testing in current customer.

Tested locally.