### PR TITLE
FIX: Avoid NullReferenceException in incident update handler

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,6 @@
+### 1.13.1 - 18 September 2024
+* Fix: An update request of Incident without a StateCode would throw NullReferenceException (@mkholt)
+
 ### 1.13.0 - 18 September 2024
 * Add support for .NET8 (@mkholt)
 * Remove support for versions older than 9 (365) (@mkholt)

--- a/src/MetadataGen/MetadataGenerator365/AssemblyInfo.fs
+++ b/src/MetadataGen/MetadataGenerator365/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.13.0")]
-[assembly: AssemblyFileVersion("1.13.0")]
+[assembly: AssemblyVersion("1.13.1")]
+[assembly: AssemblyFileVersion("1.13.1")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.13.0";
-        internal const System.String AssemblyFileVersion = "1.13.0";
+        internal const System.String AssemblyVersion = "1.13.1";
+        internal const System.String AssemblyFileVersion = "1.13.1";
     }
 }

--- a/src/XrmMockup365/AssemblyInfo.fs
+++ b/src/XrmMockup365/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.13.0")]
-[assembly: AssemblyFileVersion("1.13.0")]
+[assembly: AssemblyVersion("1.13.1")]
+[assembly: AssemblyFileVersion("1.13.1")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.13.0";
-        internal const System.String AssemblyFileVersion = "1.13.0";
+        internal const System.String AssemblyVersion = "1.13.1";
+        internal const System.String AssemblyFileVersion = "1.13.1";
     }
 }

--- a/src/XrmMockup365/XrmMockup365.csproj
+++ b/src/XrmMockup365/XrmMockup365.csproj
@@ -17,6 +17,8 @@
         <RepositoryUrl>https://github.com/delegateas/XrmMockup</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
     </PropertyGroup>
     <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
         <Optimize>false</Optimize>

--- a/src/XrmMockupShared/Requests/UpdateRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/UpdateRequestHandler.cs
@@ -72,9 +72,10 @@ namespace DG.Tools.XrmMockup
             var request = MakeRequest<UpdateRequest>(orgRequest);
             var settings = MockupExecutionContext.GetSettings(request);
 
-            if (request.Target.LogicalName is "incident" &&
-                request.Target.GetAttributeValue<OptionSetValue>("statecode").Value is 1 &&
-                !request.Parameters.ContainsKey("CloseIncidentRequestHandler"))
+            if (request.Target.LogicalName is "incident"
+                && !request.Parameters.ContainsKey("CloseIncidentRequestHandler")
+                && request.Target.TryGetAttributeValue<OptionSetValue>("statecode", out var stateCode)
+                && stateCode.Value is 1)
             {
                 throw new FaultException("This message can not be used to set the state of incident to Resolved. In order to set state of incident to Resolved, use the CloseIncidentRequest message instead.");
             }

--- a/tests/SharedTests/TestIncident.cs
+++ b/tests/SharedTests/TestIncident.cs
@@ -536,5 +536,22 @@ namespace DG.XrmMockupTest
 
             Assert.Throws<FaultException>(() => orgAdminService.Update(incident));
         }
+
+        [Fact]
+        public void TestCanUpdateOpenIncident()
+        {
+            var incident = new Incident
+            {
+                Description = nameof(TestCanUpdateOpenIncident)
+            };
+
+            incident.Id = orgAdminUIService.Create(incident);
+
+            incident.Description = "Updated description";
+            orgAdminService.Update(incident);
+
+            var retrievedIncident = Incident.Retrieve(orgAdminService, incident.Id);
+            Assert.Equal("Updated description", retrievedIncident.Description);
+        }
     }
 }


### PR DESCRIPTION
An error was introduced when state is not part of an incident update request.
Check that the parameter is set before trying to access it.