### PR TITLE
Fix plugin vs workflow execution order

### DIFF
--- a/src/XrmMockupShared/Core.cs
+++ b/src/XrmMockupShared/Core.cs
@@ -667,6 +667,8 @@ namespace DG.Tools.XrmMockup
                     workflowManager.TriggerSync(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, postImage, pluginContext, this);
                     pluginManager.TriggerSync(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, postImage, pluginContext, this, (p) => p.GetExecutionOrder() != 0);
 
+                    postImage = TryRetrieve(primaryRef);
+
                     pluginManager.StageAsync(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, postImage, pluginContext, this);
                     workflowManager.StageAsync(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, postImage, pluginContext, this);
                 }

--- a/src/XrmMockupShared/Core.cs
+++ b/src/XrmMockupShared/Core.cs
@@ -616,7 +616,7 @@ namespace DG.Tools.XrmMockup
                 // System Pre-validation
                 pluginManager.TriggerSystem(eventOp, ExecutionStage.PreValidation, entityInfo.Item1, preImage, postImage, pluginContext, this);
                 // Pre-validation
-                pluginManager.Trigger(eventOp, ExecutionStage.PreValidation, entityInfo.Item1, preImage, postImage, pluginContext, this);
+                pluginManager.TriggerSync(eventOp, ExecutionStage.PreValidation, entityInfo.Item1, preImage, postImage, pluginContext, this, (_) => true);
             }
 
             //perform security checks for the request
@@ -629,8 +629,9 @@ namespace DG.Tools.XrmMockup
                 pluginContext.SharedVariables.Clear();
 
                 // Pre-operation
-                pluginManager.Trigger(eventOp, ExecutionStage.PreOperation, entityInfo.Item1, preImage, postImage, pluginContext, this);
+                pluginManager.TriggerSync(eventOp, ExecutionStage.PreOperation, entityInfo.Item1, preImage, postImage, pluginContext, this, (p) => p.GetExecutionOrder() == 0);
                 workflowManager.TriggerSync(eventOp, ExecutionStage.PreOperation, entityInfo.Item1, preImage, postImage, pluginContext, this);
+                pluginManager.TriggerSync(eventOp, ExecutionStage.PreOperation, entityInfo.Item1, preImage, postImage, pluginContext, this, (p) => p.GetExecutionOrder() != 0);
 
                 // System Pre-operation
                 pluginManager.TriggerSystem(eventOp, ExecutionStage.PreOperation, entityInfo.Item1, preImage, postImage, pluginContext, this);
@@ -661,10 +662,12 @@ namespace DG.Tools.XrmMockup
                     CopySystemAttributes(postImage, entityInfo.Item1 as Entity);
 
                     pluginManager.TriggerSystem(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, postImage, pluginContext, this);
-                    pluginManager.TriggerSync(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, postImage, pluginContext, this);
-                    pluginManager.StageAsync(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, postImage, pluginContext, this);
 
+                    pluginManager.TriggerSync(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, postImage, pluginContext, this, (p) => p.GetExecutionOrder() == 0);
                     workflowManager.TriggerSync(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, postImage, pluginContext, this);
+                    pluginManager.TriggerSync(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, postImage, pluginContext, this, (p) => p.GetExecutionOrder() != 0);
+
+                    pluginManager.StageAsync(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, postImage, pluginContext, this);
                     workflowManager.StageAsync(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, postImage, pluginContext, this);
                 }
 

--- a/src/XrmMockupShared/Core.cs
+++ b/src/XrmMockupShared/Core.cs
@@ -602,7 +602,6 @@ namespace DG.Tools.XrmMockup
             }
 
             Entity preImage = null;
-            Entity postImage = null;
 
             if (settings.TriggerProcesses && entityInfo != null)
             {
@@ -614,9 +613,9 @@ namespace DG.Tools.XrmMockup
             if (settings.TriggerProcesses && entityInfo != null)
             {
                 // System Pre-validation
-                pluginManager.TriggerSystem(eventOp, ExecutionStage.PreValidation, entityInfo.Item1, preImage, postImage, pluginContext, this);
+                pluginManager.TriggerSystem(eventOp, ExecutionStage.PreValidation, entityInfo.Item1, preImage, null, pluginContext, this);
                 // Pre-validation
-                pluginManager.TriggerSync(eventOp, ExecutionStage.PreValidation, entityInfo.Item1, preImage, postImage, pluginContext, this, (_) => true);
+                pluginManager.TriggerSync(eventOp, ExecutionStage.PreValidation, entityInfo.Item1, preImage, null, pluginContext, this, (_) => true);
             }
 
             //perform security checks for the request
@@ -629,12 +628,12 @@ namespace DG.Tools.XrmMockup
                 pluginContext.SharedVariables.Clear();
 
                 // Pre-operation
-                pluginManager.TriggerSync(eventOp, ExecutionStage.PreOperation, entityInfo.Item1, preImage, postImage, pluginContext, this, (p) => p.GetExecutionOrder() == 0);
-                workflowManager.TriggerSync(eventOp, ExecutionStage.PreOperation, entityInfo.Item1, preImage, postImage, pluginContext, this);
-                pluginManager.TriggerSync(eventOp, ExecutionStage.PreOperation, entityInfo.Item1, preImage, postImage, pluginContext, this, (p) => p.GetExecutionOrder() != 0);
+                pluginManager.TriggerSync(eventOp, ExecutionStage.PreOperation, entityInfo.Item1, preImage, null, pluginContext, this, (p) => p.GetExecutionOrder() == 0);
+                workflowManager.TriggerSync(eventOp, ExecutionStage.PreOperation, entityInfo.Item1, preImage, null, pluginContext, this);
+                pluginManager.TriggerSync(eventOp, ExecutionStage.PreOperation, entityInfo.Item1, preImage, null, pluginContext, this, (p) => p.GetExecutionOrder() != 0);
 
                 // System Pre-operation
-                pluginManager.TriggerSystem(eventOp, ExecutionStage.PreOperation, entityInfo.Item1, preImage, postImage, pluginContext, this);
+                pluginManager.TriggerSystem(eventOp, ExecutionStage.PreOperation, entityInfo.Item1, preImage, null, pluginContext, this);
             }
 
             // Core operation
@@ -643,8 +642,6 @@ namespace DG.Tools.XrmMockup
             // Post-operation
             if (settings.TriggerProcesses && entityInfo != null)
             {
-                postImage = TryRetrieve(primaryRef);
-
                 // In RetrieveMultipleRequests, the OutputParameters bag contains the entity collection
                 if (request is RetrieveMultipleRequest)
                 {
@@ -658,19 +655,21 @@ namespace DG.Tools.XrmMockup
 
                 if (!string.IsNullOrEmpty(eventOp))
                 {
+                    var syncPostImage = TryRetrieve(primaryRef);
+
                     //copy the createon etc system attributes onto the target so they are available for postoperation processing
-                    CopySystemAttributes(postImage, entityInfo.Item1 as Entity);
+                    CopySystemAttributes(syncPostImage, entityInfo.Item1 as Entity);
 
-                    pluginManager.TriggerSystem(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, postImage, pluginContext, this);
+                    pluginManager.TriggerSystem(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, syncPostImage, pluginContext, this);
 
-                    pluginManager.TriggerSync(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, postImage, pluginContext, this, (p) => p.GetExecutionOrder() == 0);
-                    workflowManager.TriggerSync(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, postImage, pluginContext, this);
-                    pluginManager.TriggerSync(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, postImage, pluginContext, this, (p) => p.GetExecutionOrder() != 0);
+                    pluginManager.TriggerSync(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, syncPostImage, pluginContext, this, (p) => p.GetExecutionOrder() == 0);
+                    workflowManager.TriggerSync(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, syncPostImage, pluginContext, this);
+                    pluginManager.TriggerSync(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, syncPostImage, pluginContext, this, (p) => p.GetExecutionOrder() != 0);
 
-                    postImage = TryRetrieve(primaryRef);
+                    var asyncPostImage = TryRetrieve(primaryRef);
 
-                    pluginManager.StageAsync(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, postImage, pluginContext, this);
-                    workflowManager.StageAsync(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, postImage, pluginContext, this);
+                    pluginManager.StageAsync(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, asyncPostImage, pluginContext, this);
+                    workflowManager.StageAsync(eventOp, ExecutionStage.PostOperation, entityInfo.Item1, preImage, asyncPostImage, pluginContext, this);
                 }
 
                 //When last Sync has been executed we trigger the Async jobs.

--- a/tests/SharedPluginsAndCodeactivites/SharedPluginsAndCodeactivites.projitems
+++ b/tests/SharedPluginsAndCodeactivites/SharedPluginsAndCodeactivites.projitems
@@ -19,6 +19,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)AccountBothImagePlugin.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FaxPreOperationPlugin.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RetrievePlugin.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SyncAsyncTest\TestPlugin0.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UpdateIdInCreatePlugin.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ContactPostPlugin.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DirectPlugins\ContactIPluginDirectPostOp.cs" />

--- a/tests/SharedPluginsAndCodeactivites/SyncAsyncTest/Test1/Test1Plugin1.cs
+++ b/tests/SharedPluginsAndCodeactivites/SyncAsyncTest/Test1/Test1Plugin1.cs
@@ -33,7 +33,7 @@
 
             var accountUpd = new Account(account.Id)
             {
-                Name = account.Name + "Sync1"
+                Name = account.Name + "pSync1"
             };
             service.Update(accountUpd);
         }

--- a/tests/SharedPluginsAndCodeactivites/SyncAsyncTest/TestPlugin0.cs
+++ b/tests/SharedPluginsAndCodeactivites/SyncAsyncTest/TestPlugin0.cs
@@ -1,0 +1,38 @@
+﻿using DG.XrmFramework.BusinessDomain.ServiceContext;
+using System;
+
+namespace DG.Some.Namespace.Test
+{
+    public class TestPlugin0 : TestPlugin
+    {
+        public TestPlugin0()
+            : base(typeof(TestPlugin0))
+        {
+            RegisterPluginStep<Account>(
+                EventOperation.Update,
+                ExecutionStage.PostOperation,
+                Sync0NameUpdate)
+                .AddImage(ImageType.PostImage, x => x.Name)
+                .AddFilteredAttributes(x => x.EMailAddress1)
+                .SetExecutionOrder(0);
+        }
+
+        protected void Sync0NameUpdate(LocalPluginContext localContext)
+        {
+            if (localContext == null)
+            {
+                throw new ArgumentNullException("localContext");
+            }
+
+            var service = localContext.OrganizationService;
+
+            var account = GetPostImage<Account>(localContext, "PostImage");
+
+            var accountUpd = new Account(account.Id)
+            {
+                Name = account.Name + "Sync0"
+            };
+            service.Update(accountUpd);
+        }
+    }
+}

--- a/tests/SharedTests/SharedTests.projitems
+++ b/tests/SharedTests/SharedTests.projitems
@@ -19,6 +19,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)TestClone.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestCWAAccountOptional.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestDefaultBusinessUnitTeamsMembers.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestExecutionOrder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestPriorityAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestSendEmail.cs" />
     <Compile Include="..\SharedTests\TestZipSnapshot.cs" />

--- a/tests/SharedTests/TestExecutionOrder.cs
+++ b/tests/SharedTests/TestExecutionOrder.cs
@@ -10,10 +10,10 @@ namespace DG.XrmMockupTest
         public TestExecutionOrder(XrmMockupFixture fixture) : base(fixture) { crm.DisableRegisteredPlugins(true); }
 
         [Fact]
-        public void TestWorkflowBeforePluginSync()
+        public void TestSyncWorkflowThenSyncPlugin()
         {
-            crm.RegisterAdditionalPlugins(Tools.XrmMockup.PluginRegistrationScope.Temporary, typeof(Test1Plugin1));                             // Appends: Sync1
-            crm.AddWorkflow(Path.Combine("../../..", "Metadata", "Workflows", "TestSyncAsyncWorkflows", "Test2", "Test2WorkflowSync2.xml"));    // Appends: Sync2
+            crm.RegisterAdditionalPlugins(Tools.XrmMockup.PluginRegistrationScope.Temporary, typeof(Test1Plugin1));                             // Appends: pSync1
+            crm.AddWorkflow(Path.Combine("../../..", "Metadata", "Workflows", "TestSyncAsyncWorkflows", "Test2", "Test2WorkflowSync1.xml"));    // Appends: Sync1
 
             var account = new Account()
             {
@@ -21,16 +21,16 @@ namespace DG.XrmMockupTest
             };
             account.Id = orgAdminService.Create(account);
 
-            account.EMailAddress1 = "trigger";
+            account.EMailAddress1 = "trigger@test.dk";
             orgAdminService.Update(account);
 
             var retrievedAccount = Account.Retrieve(orgAdminService, account.Id, x => x.Name);
 
-            Assert.Equal(account.Name + "Sync1", retrievedAccount.Name);
+            Assert.Equal(account.Name + "pSync1", retrievedAccount.Name);
         }
 
         [Fact]
-        public void TestPluginBeforeWorkflowAsync()
+        public void TestAsyncPluginThenAsyncWorkflow()
         {
             crm.RegisterAdditionalPlugins(Tools.XrmMockup.PluginRegistrationScope.Temporary, typeof(Test2Plugin1));                             // Appends: ASync1
             crm.AddWorkflow(Path.Combine("../../..", "Metadata", "Workflows", "TestSyncAsyncWorkflows", "Test1", "Test1WorkflowASync2.xml"));   // Appends: ASync2
@@ -41,19 +41,19 @@ namespace DG.XrmMockupTest
             };
             account.Id = orgAdminService.Create(account);
 
-            account.EMailAddress1 = "trigger";
+            account.EMailAddress1 = "trigger@test.dk";
             orgAdminService.Update(account);
 
             var retrievedAccount = Account.Retrieve(orgAdminService, account.Id, x => x.Name);
 
-            Assert.Equal(account.Name + "ASync1" + "ASync2", retrievedAccount.Name);
+            Assert.Equal(account.Name + "ASync1ASync2", retrievedAccount.Name);
         }
 
         [Fact]
-        public void TestPluginBeforeWorkflowSync()
+        public void TestSyncWorkflowThenAsyncPlugin()
         {
-            crm.RegisterAdditionalPlugins(Tools.XrmMockup.PluginRegistrationScope.Temporary, typeof(TestPlugin0));                              // Appends: Sync0
-            crm.AddWorkflow(Path.Combine("../../..", "Metadata", "Workflows", "TestSyncAsyncWorkflows", "Test2", "Test2WorkflowSync2.xml"));    // Appends: Sync2
+            crm.RegisterAdditionalPlugins(Tools.XrmMockup.PluginRegistrationScope.Temporary, typeof(Test2Plugin1));                             // Appends: ASync1
+            crm.AddWorkflow(Path.Combine("../../..", "Metadata", "Workflows", "TestSyncAsyncWorkflows", "Test2", "Test2WorkflowSync1.xml"));    // Appends: Sync1
 
             var account = new Account()
             {
@@ -61,38 +61,52 @@ namespace DG.XrmMockupTest
             };
             account.Id = orgAdminService.Create(account);
 
-            account.EMailAddress1 = "trigger";
+            account.EMailAddress1 = "trigger@test.dk";
             orgAdminService.Update(account);
 
             var retrievedAccount = Account.Retrieve(orgAdminService, account.Id, x => x.Name);
 
-            Assert.Equal(account.Name + "Sync2", retrievedAccount.Name);
+            Assert.Equal(account.Name + "Sync1ASync1", retrievedAccount.Name);
         }
 
-        //[Fact]
-        //public void TestGeneralEexecutionOrder()
-        //{
-        //    crm.RegisterAdditionalPlugins(Tools.XrmMockup.PluginRegistrationScope.Temporary,
-        //        typeof(Test1Plugin1),   // Sync
-        //        typeof(Test2Plugin1));  // Async
+        [Fact]
+        public void TestSyncPluginThenAsyncWorkflow()
+        {
+            crm.RegisterAdditionalPlugins(Tools.XrmMockup.PluginRegistrationScope.Temporary, typeof(Test1Plugin1));                             // Appends: pSync1
+            crm.AddWorkflow(Path.Combine("../../..", "Metadata", "Workflows", "TestSyncAsyncWorkflows", "Test1", "Test1WorkflowASync2.xml"));   // Appends: ASync2
 
-        //    crm.AddWorkflow(Path.Combine("../../..", "Metadata", "Workflows", "TestSyncAsyncWorkflows", "Test2", "Test2WorkflowSync2.xml"));    // Sync
-        //    crm.AddWorkflow(Path.Combine("../../..", "Metadata", "Workflows", "TestSyncAsyncWorkflows", "Test1", "Test1WorkflowASync2.xml"));   // Async
+            var account = new Account()
+            {
+                Name = "Test",
+            };
+            account.Id = orgAdminService.Create(account);
 
-        //    var account = new Account()
-        //    {
-        //        Name = "Test",
-        //    };
-        //    account.Id = orgAdminService.Create(account);
+            account.EMailAddress1 = "trigger@test.dk";
+            orgAdminService.Update(account);
 
-        //    account.EMailAddress1 = "trigger";
-        //    orgAdminService.Update(account);
+            var retrievedAccount = Account.Retrieve(orgAdminService, account.Id, x => x.Name);
 
-        //    var expectedName = account.Name + "Sync2" + "Sync1" + "ASync1" + "ASync2";
+            Assert.Equal(account.Name + "pSync1ASync2", retrievedAccount.Name);
+        }
 
-        //    var retrievedAccount = Account.Retrieve(orgAdminService, account.Id, x => x.Name);
+        [Fact]
+        public void TestSyncPluginThenSyncWorkflow()
+        {
+            crm.RegisterAdditionalPlugins(Tools.XrmMockup.PluginRegistrationScope.Temporary, typeof(TestPlugin0));                              // Appends: Sync0
+            crm.AddWorkflow(Path.Combine("../../..", "Metadata", "Workflows", "TestSyncAsyncWorkflows", "Test2", "Test2WorkflowSync1.xml"));    // Appends: Sync1
 
-        //    Assert.Equal(expectedName, retrievedAccount.Name);
-        //}
+            var account = new Account()
+            {
+                Name = "Test",
+            };
+            account.Id = orgAdminService.Create(account);
+
+            account.EMailAddress1 = "trigger@test.dk";
+            orgAdminService.Update(account);
+
+            var retrievedAccount = Account.Retrieve(orgAdminService, account.Id, x => x.Name);
+
+            Assert.Equal(account.Name + "Sync1", retrievedAccount.Name);
+        }
     }
 }

--- a/tests/SharedTests/TestExecutionOrder.cs
+++ b/tests/SharedTests/TestExecutionOrder.cs
@@ -1,0 +1,98 @@
+﻿using DG.Some.Namespace.Test;
+using DG.XrmFramework.BusinessDomain.ServiceContext;
+using System.IO;
+using Xunit;
+
+namespace DG.XrmMockupTest
+{
+    public class TestExecutionOrder : UnitTestBase
+    {
+        public TestExecutionOrder(XrmMockupFixture fixture) : base(fixture) { crm.DisableRegisteredPlugins(true); }
+
+        [Fact]
+        public void TestWorkflowBeforePluginSync()
+        {
+            crm.RegisterAdditionalPlugins(Tools.XrmMockup.PluginRegistrationScope.Temporary, typeof(Test1Plugin1));                             // Appends: Sync1
+            crm.AddWorkflow(Path.Combine("../../..", "Metadata", "Workflows", "TestSyncAsyncWorkflows", "Test2", "Test2WorkflowSync2.xml"));    // Appends: Sync2
+
+            var account = new Account()
+            {
+                Name = "Test",
+            };
+            account.Id = orgAdminService.Create(account);
+
+            account.EMailAddress1 = "trigger";
+            orgAdminService.Update(account);
+
+            var retrievedAccount = Account.Retrieve(orgAdminService, account.Id, x => x.Name);
+
+            Assert.Equal(account.Name + "Sync1", retrievedAccount.Name);
+        }
+
+        [Fact]
+        public void TestPluginBeforeWorkflowAsync()
+        {
+            crm.RegisterAdditionalPlugins(Tools.XrmMockup.PluginRegistrationScope.Temporary, typeof(Test2Plugin1));                             // Appends: ASync1
+            crm.AddWorkflow(Path.Combine("../../..", "Metadata", "Workflows", "TestSyncAsyncWorkflows", "Test1", "Test1WorkflowASync2.xml"));   // Appends: ASync2
+
+            var account = new Account()
+            {
+                Name = "Test",
+            };
+            account.Id = orgAdminService.Create(account);
+
+            account.EMailAddress1 = "trigger";
+            orgAdminService.Update(account);
+
+            var retrievedAccount = Account.Retrieve(orgAdminService, account.Id, x => x.Name);
+
+            Assert.Equal(account.Name + "ASync1" + "ASync2", retrievedAccount.Name);
+        }
+
+        [Fact]
+        public void TestPluginBeforeWorkflowSync()
+        {
+            crm.RegisterAdditionalPlugins(Tools.XrmMockup.PluginRegistrationScope.Temporary, typeof(TestPlugin0));                              // Appends: Sync0
+            crm.AddWorkflow(Path.Combine("../../..", "Metadata", "Workflows", "TestSyncAsyncWorkflows", "Test2", "Test2WorkflowSync2.xml"));    // Appends: Sync2
+
+            var account = new Account()
+            {
+                Name = "Test",
+            };
+            account.Id = orgAdminService.Create(account);
+
+            account.EMailAddress1 = "trigger";
+            orgAdminService.Update(account);
+
+            var retrievedAccount = Account.Retrieve(orgAdminService, account.Id, x => x.Name);
+
+            Assert.Equal(account.Name + "Sync2", retrievedAccount.Name);
+        }
+
+        //[Fact]
+        //public void TestGeneralEexecutionOrder()
+        //{
+        //    crm.RegisterAdditionalPlugins(Tools.XrmMockup.PluginRegistrationScope.Temporary,
+        //        typeof(Test1Plugin1),   // Sync
+        //        typeof(Test2Plugin1));  // Async
+
+        //    crm.AddWorkflow(Path.Combine("../../..", "Metadata", "Workflows", "TestSyncAsyncWorkflows", "Test2", "Test2WorkflowSync2.xml"));    // Sync
+        //    crm.AddWorkflow(Path.Combine("../../..", "Metadata", "Workflows", "TestSyncAsyncWorkflows", "Test1", "Test1WorkflowASync2.xml"));   // Async
+
+        //    var account = new Account()
+        //    {
+        //        Name = "Test",
+        //    };
+        //    account.Id = orgAdminService.Create(account);
+
+        //    account.EMailAddress1 = "trigger";
+        //    orgAdminService.Update(account);
+
+        //    var expectedName = account.Name + "Sync2" + "Sync1" + "ASync1" + "ASync2";
+
+        //    var retrievedAccount = Account.Retrieve(orgAdminService, account.Id, x => x.Name);
+
+        //    Assert.Equal(expectedName, retrievedAccount.Name);
+        //}
+    }
+}

--- a/tests/SharedTests/TestSyncAsyncPlugin.cs
+++ b/tests/SharedTests/TestSyncAsyncPlugin.cs
@@ -237,16 +237,14 @@ namespace DG.XrmMockupTest
         }
 
         [Fact]
-        public void Test3Sync1AndAsync2PostPluginSucceedsWhenOnlyAsync2Applies()
+        public void Test3Sync1AndAsync2PostPluginSucceedsWhenBothApplies()
         {
-            /* Sync and Async trigger of same emailAddress1 update - Only Async applies Since it is executed last and does not use the postimage of the sync Operation */
-
             crm.RegisterAdditionalPlugins(Tools.XrmMockup.PluginRegistrationScope.Temporary,
                 typeof(Test3Plugin1),
                 typeof(Test3Plugin2));
 
             oldAccountName = "Test";
-            newAccountName = oldAccountName + "ASync2";
+            newAccountName = oldAccountName + "Sync1" + "ASync2";
 
             account = new Account()
             {
@@ -267,7 +265,7 @@ namespace DG.XrmMockupTest
         }
 
         [Fact]
-        public void Test7Sync1TriggersAsync2Sync3PostPluginSucceedsWhenSync1AndAsync2Applies()
+        public void Test7Sync1TriggersAsync2Sync3PostPluginSucceedsWhenSync3AndAsync2Applies()
         {
             crm.RegisterAdditionalPlugins(Tools.XrmMockup.PluginRegistrationScope.Temporary,
                 typeof(Test7Plugin1),
@@ -275,7 +273,7 @@ namespace DG.XrmMockupTest
                 typeof(Test7Plugin3));
 
             oldAccountName = "Test";
-            newAccountName = oldAccountName + "Sync1ASync2";
+            newAccountName = oldAccountName + "Sync3ASync2";
 
             account = new Account()
             {
@@ -297,7 +295,7 @@ namespace DG.XrmMockupTest
 
 
         [Fact]
-        public void Test8Async2Sync1TriggersSync3SucceedsWhenAsync2Applies()
+        public void Test8Async2Sync1TriggersSync3SucceedsWhenAllApplies()
         {
             crm.RegisterAdditionalPlugins(Tools.XrmMockup.PluginRegistrationScope.Temporary,
                 typeof(Test8Plugin1),
@@ -305,7 +303,7 @@ namespace DG.XrmMockupTest
                 typeof(Test8Plugin3));
 
             oldAccountName = "Test";
-            newAccountName = oldAccountName + "ASync2";
+            newAccountName = oldAccountName + "Sync1" + "Sync3" + "ASync2";
 
             account = new Account()
             {


### PR DESCRIPTION
Fixes #94 

- Rewrite PluginManager to collect synchronous trigger functionality within one function
- Use new function to execute plugins with execution order zero first. Then real-time workflows. Then remaining synchronous plugins.
- Update postImage after synchronous logic have executed and save it in a new dedicated variable
- Align 'StageAsync' with rewritten function 'TriggerSync'
- Test using existing plugins and workflows as well as one new plugin with execution order zero