### PR TITLE
Implemented InstantiateTemplateRequest

### DIFF
--- a/src/XrmMockupShared/Core.cs
+++ b/src/XrmMockupShared/Core.cs
@@ -1,20 +1,20 @@
-﻿using System;
+﻿using DG.Tools.XrmMockup.Database;
+using DG.Tools.XrmMockup.Serialization;
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Client;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Metadata;
+using Microsoft.Xrm.Sdk.Organization;
+using Microsoft.Xrm.Sdk.Query;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.Xrm.Sdk;
-using Microsoft.Xrm.Sdk.Messages;
-using Microsoft.Xrm.Sdk.Query;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using Microsoft.Crm.Sdk.Messages;
 using System.ServiceModel;
-using Microsoft.Xrm.Sdk.Metadata;
-using DG.Tools.XrmMockup.Database;
-using Microsoft.Xrm.Sdk.Client;
-using WorkflowExecuter;
 using System.Text.Json;
-using DG.Tools.XrmMockup.Serialization;
-using Microsoft.Xrm.Sdk.Organization;
+using WorkflowExecuter;
 
 [assembly: InternalsVisibleTo("SharedTests")]
 
@@ -211,6 +211,7 @@ namespace DG.Tools.XrmMockup
             new InitializeFileBlocksUploadRequestHandler(this, db, metadata, security),
             new UploadBlockRequestHandler(this, db, metadata, security),
             new CommitFileBlocksUploadRequestHandler(this, db, metadata, security),
+            new InstantiateTemplateRequestHandler(this, db, metadata, security),
         };
 
         internal void EnableProxyTypes(Assembly assembly)
@@ -695,8 +696,8 @@ namespace DG.Tools.XrmMockup
             switch (request.RequestName)
             {
                 case "Create":
-                    var createResponse = (CreateResponse) response;
-                    var entityLogicalName = ((Entity) request.Parameters["Target"]).LogicalName;
+                    var createResponse = (CreateResponse)response;
+                    var entityLogicalName = ((Entity)request.Parameters["Target"]).LogicalName;
 
                     var createdEntity =
                         GetDbRow(new EntityReference(entityLogicalName, createResponse.id))
@@ -706,7 +707,7 @@ namespace DG.Tools.XrmMockup
                         createdEntity, null, userRef);
                     break;
                 case "Update":
-                    var target = (Entity) request.Parameters["Target"];
+                    var target = (Entity)request.Parameters["Target"];
                     var updatedEntity = GetDbRow(target.ToEntityReferenceWithKeyAttributes()).ToEntity();
                     TriggerExtension(
                         new MockupService(this, userRef.Id, pluginContext), request,

--- a/src/XrmMockupShared/Requests/InstantiateTemplateRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/InstantiateTemplateRequestHandler.cs
@@ -1,6 +1,8 @@
 using DG.Tools.XrmMockup.Database;
 using Microsoft.Crm.Sdk.Messages;
 using Microsoft.Xrm.Sdk;
+using System;
+using System.ServiceModel;
 
 namespace DG.Tools.XrmMockup
 {
@@ -11,6 +13,15 @@ namespace DG.Tools.XrmMockup
         internal override OrganizationResponse Execute(OrganizationRequest orgRequest, EntityReference userRef)
         {
             var request = MakeRequest<InstantiateTemplateRequest>(orgRequest);
+
+            if (request.TemplateId == Guid.Empty)
+                throw new FaultException("Template id should be set.");
+
+            if (request.ObjectId == Guid.Empty)
+                throw new FaultException("Object id should be set.");
+
+            if (string.IsNullOrEmpty(request.ObjectType))
+                throw new FaultException("ObjectType is missing");
 
             var entity = new Entity("email");
 

--- a/src/XrmMockupShared/Requests/InstantiateTemplateRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/InstantiateTemplateRequestHandler.cs
@@ -1,0 +1,32 @@
+using DG.Tools.XrmMockup.Database;
+using Microsoft.Crm.Sdk.Messages;
+using Microsoft.Xrm.Sdk;
+
+namespace DG.Tools.XrmMockup
+{
+    internal class InstantiateTemplateRequestHandler : RequestHandler
+    {
+        public InstantiateTemplateRequestHandler(Core core, XrmDb db, MetadataSkeleton metadata, Security security) : base(core, db, metadata, security, "InstantiateTemplate") { }
+
+        internal override OrganizationResponse Execute(OrganizationRequest orgRequest, EntityReference userRef)
+        {
+            var request = MakeRequest<InstantiateTemplateRequest>(orgRequest);
+
+            var entity = new Entity("email");
+
+            var collection = new EntityCollection();
+            collection.Entities.Add(entity);
+
+            var parameters = new ParameterCollection
+            {
+                { "EntityCollection", collection }
+            };
+
+            return new InstantiateTemplateResponse
+            {
+                Results = parameters,
+                ResponseName = "InstantiateTemplate",
+            };
+        }
+    }
+}

--- a/src/XrmMockupShared/XrmMockupShared.projitems
+++ b/src/XrmMockupShared/XrmMockupShared.projitems
@@ -15,6 +15,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)MockupServiceAsync2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MockupServiceAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Requests\CommitFileBlocksUploadRequestHandler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)requests\InstantiateTemplateRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Requests\UploadBlockRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Requests\InitializeFileBlocksUploadRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Requests\SendEmailRequestHandler.cs" />

--- a/tests/SharedTests/SharedTests.projitems
+++ b/tests/SharedTests/SharedTests.projitems
@@ -19,6 +19,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)TestClone.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestCWAAccountOptional.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestDefaultBusinessUnitTeamsMembers.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TestInstantiateTemplate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestPriorityAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestSendEmail.cs" />
     <Compile Include="..\SharedTests\TestZipSnapshot.cs" />

--- a/tests/SharedTests/TestInstantiateTemplate.cs
+++ b/tests/SharedTests/TestInstantiateTemplate.cs
@@ -1,0 +1,65 @@
+using Microsoft.Crm.Sdk.Messages;
+using System;
+using System.ServiceModel;
+using Xunit;
+
+namespace DG.XrmMockupTest
+{
+    public class TestInstantiateTemplate : UnitTestBase
+    {
+        public TestInstantiateTemplate(XrmMockupFixture fixture) : base(fixture) { }
+
+        [Fact]
+        public void TestInstantiateTemplateRequestReturnsResponseWithEmail()
+        {
+            var templateRequest = new InstantiateTemplateRequest
+            {
+                TemplateId = Guid.NewGuid(),
+                ObjectId = Guid.NewGuid(),
+                ObjectType = "account"
+            };
+
+            var response = orgAdminUIService.Execute(templateRequest) as InstantiateTemplateResponse;
+
+            Assert.Single(response.EntityCollection.Entities);
+            Assert.Equal("email", response.EntityCollection.Entities[0].LogicalName);
+        }
+
+        [Fact]
+        public void TestInstantiateTemplateRequest_ThrowsFaultException_WhenTemplateIdIsNull()
+        {
+            var templateRequest = new InstantiateTemplateRequest
+            {
+                ObjectId = Guid.NewGuid(),
+                ObjectType = "account"
+            };
+
+            Assert.Throws<FaultException>(() => orgAdminUIService.Execute(templateRequest));
+        }
+
+        [Fact]
+        public void TestInstantiateTemplateRequest_ThrowsFaultException_WhenObjectIdIsNull()
+        {
+            var templateRequest = new InstantiateTemplateRequest
+            {
+                TemplateId = Guid.NewGuid(),
+                ObjectType = "account"
+            };
+
+            Assert.Throws<FaultException>(() => orgAdminUIService.Execute(templateRequest));
+        }
+
+        [Fact]
+        public void TestInstantiateTemplateRequest_ThrowsFaultException_WhenObjectTypeIsNull()
+        {
+            var templateRequest = new InstantiateTemplateRequest
+            {
+                TemplateId = Guid.NewGuid(),
+                ObjectId = Guid.NewGuid()
+            };
+
+            Assert.Throws<FaultException>(() => orgAdminUIService.Execute(templateRequest));
+        }
+    }
+}
+

--- a/tests/SharedTests/TestSendEmail.cs
+++ b/tests/SharedTests/TestSendEmail.cs
@@ -23,17 +23,17 @@ namespace DG.XrmMockupTest
 
             var email = new Email
             {
-                From = new ActivityParty[] 
-                { 
-                    new ActivityParty 
-                    { 
+                From = new ActivityParty[]
+                {
+                    new ActivityParty
+                    {
                         PartyId = crm.AdminUser
-                    } 
+                    }
                 },
-                To = new ActivityParty[] 
-                { 
-                    new ActivityParty 
-                    { 
+                To = new ActivityParty[]
+                {
+                    new ActivityParty
+                    {
                         PartyId = contact.ToEntityReference()
                     }
                 },
@@ -356,6 +356,22 @@ namespace DG.XrmMockupTest
             };
 
             Assert.Throws<FaultException>(() => orgAdminUIService.Execute(sendEmailRequest));
+        }
+
+        [Fact]
+        public void TestInstantiateTemplateRequestReturnsInstantiateTemplateResponseWithEmail()
+        {
+            var templateRequest = new InstantiateTemplateRequest
+            {
+                TemplateId = Guid.NewGuid(),
+                ObjectId = Guid.NewGuid(),
+                ObjectType = "account"
+            };
+
+            var response = orgAdminUIService.Execute(templateRequest) as InstantiateTemplateResponse;
+
+            Assert.Single(response.EntityCollection.Entities);
+            Assert.Equal("email", response.EntityCollection.Entities[0].LogicalName);
         }
     }
 }

--- a/tests/SharedTests/TestSendEmail.cs
+++ b/tests/SharedTests/TestSendEmail.cs
@@ -1,6 +1,5 @@
 ﻿using DG.XrmFramework.BusinessDomain.ServiceContext;
 using Microsoft.Crm.Sdk.Messages;
-using System;
 using System.Linq;
 using System.ServiceModel;
 using Xunit;
@@ -356,22 +355,6 @@ namespace DG.XrmMockupTest
             };
 
             Assert.Throws<FaultException>(() => orgAdminUIService.Execute(sendEmailRequest));
-        }
-
-        [Fact]
-        public void TestInstantiateTemplateRequestReturnsInstantiateTemplateResponseWithEmail()
-        {
-            var templateRequest = new InstantiateTemplateRequest
-            {
-                TemplateId = Guid.NewGuid(),
-                ObjectId = Guid.NewGuid(),
-                ObjectType = "account"
-            };
-
-            var response = orgAdminUIService.Execute(templateRequest) as InstantiateTemplateResponse;
-
-            Assert.Single(response.EntityCollection.Entities);
-            Assert.Equal("email", response.EntityCollection.Entities[0].LogicalName);
         }
     }
 }


### PR DESCRIPTION
Reorganized and updated `using` directives in `Core.cs` for better code organization. Added `InstantiateTemplateRequestHandler` to `InitializeDB` method in `Core.cs` to handle `InstantiateTemplate` requests. 

Updated `XrmMockupShared.projitems` to include `InstantiateTemplateRequestHandler.cs`.

Added new file `InstantiateTemplateRequestHandler.cs` defining the `InstantiateTemplateRequestHandler` class, which handles `InstantiateTemplate` requests by creating an `email` entity and returning it in an `EntityCollection` within the `InstantiateTemplateResponse`. Added validation checks in `Execute` method for `TemplateId`, `ObjectId`, and `ObjectType`. Throws `FaultException` if any validation fails.

Added tests for `InstantiateTemplateRequest` validation and response.