### PR TITLE
Add support for UpdateMultiple and UpsertMultiple requests

### DIFF
--- a/src/MetadataGen/MetadataGenerator365/AssemblyInfo.fs
+++ b/src/MetadataGen/MetadataGenerator365/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.13.3")]
-[assembly: AssemblyFileVersion("1.13.3")]
+[assembly: AssemblyVersion("1.14.0")]
+[assembly: AssemblyFileVersion("1.14.0")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.13.3";
-        internal const System.String AssemblyFileVersion = "1.13.3";
+        internal const System.String AssemblyVersion = "1.14.0";
+        internal const System.String AssemblyFileVersion = "1.14.0";
     }
 }

--- a/src/XrmMockup365/AssemblyInfo.fs
+++ b/src/XrmMockup365/AssemblyInfo.fs
@@ -7,8 +7,8 @@ using System.Reflection;
 [assembly: AssemblyDescription("A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.")]
 [assembly: AssemblyCompany("Delegate A/S")]
 [assembly: AssemblyCopyright("Copyright (c) Delegate A/S 2017")]
-[assembly: AssemblyVersion("1.13.3")]
-[assembly: AssemblyFileVersion("1.13.3")]
+[assembly: AssemblyVersion("1.14.0")]
+[assembly: AssemblyFileVersion("1.14.0")]
 namespace System {
     internal static class AssemblyVersionInformation {
         internal const System.String AssemblyTitle = "XrmMockup";
@@ -16,7 +16,7 @@ namespace System {
         internal const System.String AssemblyDescription = "A simulation engine that can mock a specific MS CRM instance. Useful for testing and debugging business logic.";
         internal const System.String AssemblyCompany = "Delegate A/S";
         internal const System.String AssemblyCopyright = "Copyright (c) Delegate A/S 2017";
-        internal const System.String AssemblyVersion = "1.13.3";
-        internal const System.String AssemblyFileVersion = "1.13.3";
+        internal const System.String AssemblyVersion = "1.14.0";
+        internal const System.String AssemblyFileVersion = "1.14.0";
     }
 }

--- a/src/XrmMockup365/XrmMockup365.csproj
+++ b/src/XrmMockup365/XrmMockup365.csproj
@@ -77,9 +77,6 @@
 		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.3" />
 		<PackageReference Include="UiPath.Workflow" Version="6.0.3" />
 	</ItemGroup>
-	<ItemGroup>
-		<Compile Include="..\XrmMockupShared\Requests\CreateMultipleRequestHandler.cs" />
-	</ItemGroup>
     <Import Project="..\XrmMockupShared\XrmMockupShared.projitems" Label="Shared" />
     <Import Project="..\XrmMockupWorkflow\XrmMockupWorkflow.projitems" Label="Shared" />
     <Import Project="..\MetadataSkeleton\MetadataSkeleton.projitems" Label="Shared" />

--- a/src/XrmMockupShared/Core.cs
+++ b/src/XrmMockupShared/Core.cs
@@ -215,7 +215,8 @@ namespace DG.Tools.XrmMockup
             new CommitFileBlocksUploadRequestHandler(this, db, metadata, security),
             new InstantiateTemplateRequestHandler(this, db, metadata, security),
             new CreateMultipleRequestHandler(this, db, metadata, security),
-            new UpdateMultipleRequestHandler(this, db, metadata, security)
+            new UpdateMultipleRequestHandler(this, db, metadata, security),
+            new UpsertMultipleRequestHandler(this, db, metadata, security)
         };
 
         internal void EnableProxyTypes(Assembly assembly)
@@ -668,16 +669,18 @@ namespace DG.Tools.XrmMockup
                     var syncPostImage = TryRetrieve(primaryRef);
 
                     //copy the createon etc system attributes onto the target so they are available for postoperation processing
-                    CopySystemAttributes(syncPostImage, entityInfo.Item1 as Entity);
+                    if (syncPostImage != null)
+                    {
+                        CopySystemAttributes(syncPostImage, entityInfo.Item1 as Entity);
+                    }
 
                     pluginManager.TriggerSystem(operation, ExecutionStage.PostOperation, entityInfo.Item1, preImage, syncPostImage, pluginContext, this);
 
                     pluginManager.TriggerSync(operation, ExecutionStage.PostOperation, entityInfo.Item1, preImage, syncPostImage, pluginContext, this, (p) => p.GetExecutionOrder() == 0);
                     workflowManager.TriggerSync(operation, ExecutionStage.PostOperation, entityInfo.Item1, preImage, syncPostImage, pluginContext, this);
                     pluginManager.TriggerSync(operation, ExecutionStage.PostOperation, entityInfo.Item1, preImage, syncPostImage, pluginContext, this, (p) => p.GetExecutionOrder() != 0);
-
+                    
                     var asyncPostImage = TryRetrieve(primaryRef);
-
                     pluginManager.StageAsync(operation, ExecutionStage.PostOperation, entityInfo.Item1, preImage, asyncPostImage, pluginContext, this);
                     workflowManager.StageAsync(operation, ExecutionStage.PostOperation, entityInfo.Item1, preImage, asyncPostImage, pluginContext, this);
                 }

--- a/src/XrmMockupShared/Core.cs
+++ b/src/XrmMockupShared/Core.cs
@@ -215,6 +215,7 @@ namespace DG.Tools.XrmMockup
             new CommitFileBlocksUploadRequestHandler(this, db, metadata, security),
             new InstantiateTemplateRequestHandler(this, db, metadata, security),
             new CreateMultipleRequestHandler(this, db, metadata, security),
+            new UpdateMultipleRequestHandler(this, db, metadata, security)
         };
 
         internal void EnableProxyTypes(Assembly assembly)

--- a/src/XrmMockupShared/Database/XrmDb.cs
+++ b/src/XrmMockupShared/Database/XrmDb.cs
@@ -183,7 +183,7 @@ namespace DG.Tools.XrmMockup.Database {
             DbRow currentDbRow = null;
             dbRow = null;
 
-            if (reference?.Id != Guid.Empty)
+            if (reference?.Id != default && reference?.Id != Guid.Empty)
             {
                 currentDbRow = this[reference.LogicalName][reference.Id];
                 if (currentDbRow == null)

--- a/src/XrmMockupShared/Domain.cs
+++ b/src/XrmMockupShared/Domain.cs
@@ -143,6 +143,7 @@ namespace DG.Tools.XrmMockup {
         UnlockInvoicePricing,
         UnlockSalesOrderPricing,
         Update,
+        UpdateMultiple,
         ValidateRecurrenceRule,
         Win
     }

--- a/src/XrmMockupShared/Domain.cs
+++ b/src/XrmMockupShared/Domain.cs
@@ -144,6 +144,8 @@ namespace DG.Tools.XrmMockup {
         UnlockSalesOrderPricing,
         Update,
         UpdateMultiple,
+        Upsert,
+        UpsertMultiple,
         ValidateRecurrenceRule,
         Win
     }

--- a/src/XrmMockupShared/Mappings.cs
+++ b/src/XrmMockupShared/Mappings.cs
@@ -4,6 +4,7 @@ using Microsoft.Xrm.Sdk.Messages;
 using Microsoft.Xrm.Sdk.Query;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 namespace DG.Tools.XrmMockup {
@@ -29,30 +30,48 @@ namespace DG.Tools.XrmMockup {
             { typeof(UpdateMultipleRequest), "Targets" },
         };
 
-        public static Dictionary<Type, string> RequestToEventOperation = new Dictionary<Type, string>()
+        public static Dictionary<Type, EventOperation?> RequestToEventOperation = new Dictionary<Type, EventOperation?>()
         {
-            { typeof(AssignRequest), nameof(EventOperation.Assign).ToLower() },
-            { typeof(AssociateRequest), nameof(EventOperation.Associate).ToLower() },
-            { typeof(CreateRequest),nameof( EventOperation.Create).ToLower() },
-            { typeof(DeleteRequest), nameof(EventOperation.Delete).ToLower() },
-            { typeof(DisassociateRequest), nameof(EventOperation.Disassociate).ToLower() },
-            { typeof(GrantAccessRequest), nameof(EventOperation.GrantAccess).ToLower() },
-            { typeof(MergeRequest), nameof(EventOperation.Merge).ToLower() },
-            { typeof(ModifyAccessRequest), nameof(EventOperation.ModifyAccess).ToLower() },
-            { typeof(RetrieveRequest), nameof(EventOperation.Retrieve).ToLower() },
-            { typeof(RetrieveMultipleRequest), nameof(EventOperation.RetrieveMultiple).ToLower() },
-            { typeof(RetrievePrincipalAccessRequest), nameof(EventOperation.RetrievePrincipalAccess).ToLower() },
+            { typeof(AssignRequest), EventOperation.Assign },
+            { typeof(AssociateRequest), EventOperation.Associate },
+            { typeof(CreateRequest), EventOperation.Create },
+            { typeof(DeleteRequest), EventOperation.Delete },
+            { typeof(DisassociateRequest), EventOperation.Disassociate },
+            { typeof(GrantAccessRequest), EventOperation.GrantAccess },
+            { typeof(MergeRequest), EventOperation.Merge },
+            { typeof(ModifyAccessRequest), EventOperation.ModifyAccess },
+            { typeof(RetrieveRequest), EventOperation.Retrieve },
+            { typeof(RetrieveMultipleRequest), EventOperation.RetrieveMultiple },
+            { typeof(RetrievePrincipalAccessRequest), EventOperation.RetrievePrincipalAccess },
             //{ typeof(RetrieveSharedPrincipalAccessRequest), EventOperation.RetrieveSharedPrincipalAccess }, // No such request
-            { typeof(RevokeAccessRequest), nameof(EventOperation.RevokeAccess).ToLower() },
-            { typeof(SetStateRequest), nameof(EventOperation.SetState).ToLower() },
+            { typeof(RevokeAccessRequest), EventOperation.RevokeAccess },
+            { typeof(SetStateRequest), EventOperation.SetState },
             //{ typeof(SetStateDynamicEntityRequest), EventOperation.SetStateDynamicEntity }, // No such request
-            { typeof(UpdateRequest), nameof(EventOperation.Update).ToLower() },
-            { typeof(WinOpportunityRequest), nameof(EventOperation.Win).ToLower() },
-            { typeof(LoseOpportunityRequest), nameof(EventOperation.Lose).ToLower() },
-            { typeof(CloseIncidentRequest), nameof(EventOperation.Close).ToLower() },
-            { typeof(CreateMultipleRequest), nameof(EventOperation.CreateMultiple).ToLower() },
-            { typeof(UpdateMultipleRequest), nameof(EventOperation.UpdateMultiple).ToLower() }
+            { typeof(UpdateRequest), EventOperation.Update },
+            { typeof(WinOpportunityRequest), EventOperation.Win },
+            { typeof(LoseOpportunityRequest), EventOperation.Lose },
+            { typeof(CloseIncidentRequest), EventOperation.Close },
+            { typeof(CreateMultipleRequest), EventOperation.CreateMultiple },
+            { typeof(UpdateMultipleRequest), EventOperation.UpdateMultiple }
         };
+
+        public static Dictionary<EventOperation, EventOperation> RequestToMultipleRequest = new Dictionary<EventOperation, EventOperation>()
+        {
+            { EventOperation.Create, EventOperation.CreateMultiple },
+            { EventOperation.Update, EventOperation.UpdateMultiple }
+        };
+
+        public static EventOperation? SingleOperationFromMultiple(EventOperation operation)
+        {
+            if (!RequestToMultipleRequest.ContainsValue(operation)) return null;
+            return RequestToMultipleRequest.First(x => x.Value == operation).Key;
+        }
+
+        public static Type EventOperationToRequest(EventOperation operation)
+        {
+            if (!RequestToEventOperation.ContainsValue(operation)) return null;
+            return RequestToEventOperation.First(x => x.Value == operation).Key;
+        }
 
         public static readonly Dictionary<string, ConditionOperator> ConditionalOperator = new Dictionary<string, ConditionOperator>
         {

--- a/src/XrmMockupShared/Mappings.cs
+++ b/src/XrmMockupShared/Mappings.cs
@@ -13,21 +13,23 @@ namespace DG.Tools.XrmMockup {
 
         public static Dictionary<Type, string> EntityImageProperty = new Dictionary<Type, string>()
         {
-            { typeof(AssignRequest), "Target" },
-            { typeof(CreateRequest), "Target" },
-            { typeof(DeleteRequest), "Target" },
-            { typeof(DeliverIncomingEmailRequest), "EmailId" },
-            { typeof(DeliverPromoteEmailRequest), "EmailId" },
-            { typeof(ExecuteWorkflowRequest), "Target" },
-            { typeof(MergeRequest), "Target" },
-            { typeof(SendEmailRequest), "EmailId" },
-            { typeof(SetStateRequest), "EntityMoniker" },
-            { typeof(UpdateRequest), "Target" },
-            { typeof(AssociateRequest), "Target" },
-            { typeof(DisassociateRequest), "Target" },
-            { typeof(RetrieveRequest), "Target" },
-            { typeof(CreateMultipleRequest), "Targets" },
-            { typeof(UpdateMultipleRequest), "Targets" },
+            { typeof(AssignRequest), nameof(AssignRequest.Target) },
+            { typeof(AssociateRequest), nameof(AssociateRequest.Target) },
+            { typeof(CreateMultipleRequest), nameof(CreateMultipleRequest.Targets) },
+            { typeof(CreateRequest), nameof(CreateRequest.Target) },
+            { typeof(DeleteRequest), nameof(DeleteRequest.Target) },
+            { typeof(DeliverIncomingEmailRequest), nameof(DeliverIncomingEmailRequest.MessageId) },
+            { typeof(DeliverPromoteEmailRequest), nameof(DeliverPromoteEmailRequest.EmailId) },
+            { typeof(DisassociateRequest), nameof(DisassociateRequest.Target) },
+            { typeof(ExecuteWorkflowRequest), nameof(ExecuteWorkflowRequest.EntityId) },
+            { typeof(MergeRequest), nameof(MergeRequest.Target) },
+            { typeof(RetrieveRequest), nameof(RetrieveRequest.Target) },
+            { typeof(SendEmailRequest), nameof(SendEmailRequest.EmailId) },
+            { typeof(SetStateRequest), nameof(SetStateRequest.EntityMoniker) },
+            { typeof(UpdateMultipleRequest), nameof(UpdateMultipleRequest.Targets) },
+            { typeof(UpdateRequest), nameof(UpdateRequest.Target) },
+            { typeof(UpsertMultipleRequest), nameof(UpsertMultipleRequest.Targets) },
+            { typeof(UpsertRequest), nameof(UpsertRequest.Target) },
         };
 
         public static Dictionary<Type, EventOperation?> RequestToEventOperation = new Dictionary<Type, EventOperation?>()
@@ -48,17 +50,20 @@ namespace DG.Tools.XrmMockup {
             { typeof(SetStateRequest), EventOperation.SetState },
             //{ typeof(SetStateDynamicEntityRequest), EventOperation.SetStateDynamicEntity }, // No such request
             { typeof(UpdateRequest), EventOperation.Update },
+            { typeof(UpsertRequest), EventOperation.Upsert },
             { typeof(WinOpportunityRequest), EventOperation.Win },
             { typeof(LoseOpportunityRequest), EventOperation.Lose },
             { typeof(CloseIncidentRequest), EventOperation.Close },
             { typeof(CreateMultipleRequest), EventOperation.CreateMultiple },
-            { typeof(UpdateMultipleRequest), EventOperation.UpdateMultiple }
+            { typeof(UpdateMultipleRequest), EventOperation.UpdateMultiple },
+            { typeof(UpsertMultipleRequest), EventOperation.UpsertMultiple }
         };
 
         public static Dictionary<EventOperation, EventOperation> RequestToMultipleRequest = new Dictionary<EventOperation, EventOperation>()
         {
             { EventOperation.Create, EventOperation.CreateMultiple },
-            { EventOperation.Update, EventOperation.UpdateMultiple }
+            { EventOperation.Update, EventOperation.UpdateMultiple },
+            { EventOperation.Upsert, EventOperation.UpsertMultiple }
         };
 
         public static EventOperation? SingleOperationFromMultiple(EventOperation operation)
@@ -149,6 +154,8 @@ namespace DG.Tools.XrmMockup {
                     return createRequest.Target.ToEntityReferenceWithKeyAttributes();
                 case UpdateRequest updateRequest:
                     return updateRequest.Target.ToEntityReferenceWithKeyAttributes();
+                case UpsertRequest upsertRequest:
+                    return upsertRequest.Target.ToEntityReferenceWithKeyAttributes();
                 case DeleteRequest deleteRequest:
                     return deleteRequest.Target;
                 case SetStateRequest setStateRequest:
@@ -169,10 +176,6 @@ namespace DG.Tools.XrmMockup {
                     return GetPrimaryEntityReferenceFromQuery(retrieveMultipleRequest.Query);
                 case CloseIncidentRequest closeIncidentRequest:
                     return closeIncidentRequest.IncidentResolution?.GetAttributeValue<EntityReference>("incidentid");
-                case CreateMultipleRequest createMultipleRequest:
-                    return new EntityReference(createMultipleRequest.Targets.EntityName, Guid.Empty);
-                case UpdateMultipleRequest updateMultipleRequest:
-                    return new EntityReference(updateMultipleRequest.Targets.EntityName, Guid.Empty);
             }
 
             return null;

--- a/src/XrmMockupShared/Mappings.cs
+++ b/src/XrmMockupShared/Mappings.cs
@@ -26,6 +26,7 @@ namespace DG.Tools.XrmMockup {
             { typeof(DisassociateRequest), "Target" },
             { typeof(RetrieveRequest), "Target" },
             { typeof(CreateMultipleRequest), "Targets" },
+            { typeof(UpdateMultipleRequest), "Targets" },
         };
 
         public static Dictionary<Type, string> RequestToEventOperation = new Dictionary<Type, string>()
@@ -50,6 +51,7 @@ namespace DG.Tools.XrmMockup {
             { typeof(LoseOpportunityRequest), nameof(EventOperation.Lose).ToLower() },
             { typeof(CloseIncidentRequest), nameof(EventOperation.Close).ToLower() },
             { typeof(CreateMultipleRequest), nameof(EventOperation.CreateMultiple).ToLower() },
+            { typeof(UpdateMultipleRequest), nameof(EventOperation.UpdateMultiple).ToLower() }
         };
 
         public static readonly Dictionary<string, ConditionOperator> ConditionalOperator = new Dictionary<string, ConditionOperator>
@@ -150,6 +152,8 @@ namespace DG.Tools.XrmMockup {
                     return closeIncidentRequest.IncidentResolution?.GetAttributeValue<EntityReference>("incidentid");
                 case CreateMultipleRequest createMultipleRequest:
                     return new EntityReference(createMultipleRequest.Targets.EntityName, Guid.Empty);
+                case UpdateMultipleRequest updateMultipleRequest:
+                    return new EntityReference(updateMultipleRequest.Targets.EntityName, Guid.Empty);
             }
 
             return null;

--- a/src/XrmMockupShared/Plugin/PluginContext.cs
+++ b/src/XrmMockupShared/Plugin/PluginContext.cs
@@ -210,7 +210,10 @@ namespace DG.Tools.XrmMockup {
         public Guid PrimaryEntityId {
             get {
                 _propertyBag.TryGetValue("PrimaryEntityId", out object PrimaryEntityId);
-                return (Guid)PrimaryEntityId;
+
+                return (PrimaryEntityId is Guid guid)
+                    ? guid
+                    : Guid.Empty;
             }
             set {
                 _propertyBag["PrimaryEntityId"] = value;

--- a/src/XrmMockupShared/Requests/CreateMultipleRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/CreateMultipleRequestHandler.cs
@@ -10,7 +10,7 @@ namespace DG.Tools.XrmMockup
     internal class CreateMultipleRequestHandler : RequestHandler
     {
         internal CreateMultipleRequestHandler(Core core, XrmDb db, MetadataSkeleton metadata, Security security) 
-            : base(core, db, metadata, security, "CreateMultiple")
+            : base(core, db, metadata, security, nameof(EventOperation.CreateMultiple))
         {
         }
 

--- a/src/XrmMockupShared/Requests/UpdateMultipleRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/UpdateMultipleRequestHandler.cs
@@ -18,8 +18,15 @@ namespace DG.Tools.XrmMockup
         {
             var request = MakeRequest<UpdateMultipleRequest>(orgRequest);
 
+            var seenIds = new HashSet<Guid>();
             foreach (var entity in request.Targets.Entities)
             {
+                if (seenIds.Contains(entity.Id))
+                {
+                    continue;
+                }
+
+                seenIds.Add(entity.Id);
                 var updateRequest = new UpdateRequest
                 {
                     Target = entity

--- a/src/XrmMockupShared/Requests/UpdateMultipleRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/UpdateMultipleRequestHandler.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using System.Linq;
+using DG.Tools.XrmMockup.Database;
+
+namespace DG.Tools.XrmMockup
+{
+    internal class UpdateMultipleRequestHandler : RequestHandler
+    {
+        internal UpdateMultipleRequestHandler(Core core, XrmDb db, MetadataSkeleton metadata, Security security) 
+            : base(core, db, metadata, security, nameof(EventOperation.UpdateMultiple))
+        {
+        }
+
+        internal override OrganizationResponse Execute(OrganizationRequest orgRequest, EntityReference userRef)
+        {
+            var request = MakeRequest<UpdateMultipleRequest>(orgRequest);
+
+            foreach (var entity in request.Targets.Entities)
+            {
+                var updateRequest = new UpdateRequest
+                {
+                    Target = entity
+                };
+
+                core.Execute(updateRequest, userRef);
+            }
+
+            return new UpdateMultipleResponse();
+        }
+    }
+}

--- a/src/XrmMockupShared/Requests/UpsertMultipleRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/UpsertMultipleRequestHandler.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using System.Linq;
+using DG.Tools.XrmMockup.Database;
+
+namespace DG.Tools.XrmMockup
+{
+    internal class UpsertMultipleRequestHandler : RequestHandler
+    {
+        internal UpsertMultipleRequestHandler(Core core, XrmDb db, MetadataSkeleton metadata, Security security) 
+            : base(core, db, metadata, security, nameof(EventOperation.UpsertMultiple))
+        {
+        }
+
+        internal override OrganizationResponse Execute(OrganizationRequest orgRequest, EntityReference userRef)
+        {
+            var request = MakeRequest<UpsertMultipleRequest>(orgRequest);
+
+            var results = request.Targets.Entities.Select(entity =>
+            {
+                var upsertRequest = new UpsertRequest
+                {
+                    Target = entity
+                };
+
+                return core.Execute(upsertRequest, userRef);
+            }).Cast<UpsertResponse>().ToArray();
+
+            var response = new UpsertMultipleResponse();
+            response["Results"] = results;
+
+            return response;
+        }
+    }
+}

--- a/src/XrmMockupShared/Requests/UpsertMultipleRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/UpsertMultipleRequestHandler.cs
@@ -4,6 +4,7 @@ using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
 using System.Linq;
 using DG.Tools.XrmMockup.Database;
+using System.ServiceModel;
 
 namespace DG.Tools.XrmMockup
 {
@@ -17,9 +18,16 @@ namespace DG.Tools.XrmMockup
         internal override OrganizationResponse Execute(OrganizationRequest orgRequest, EntityReference userRef)
         {
             var request = MakeRequest<UpsertMultipleRequest>(orgRequest);
+            var seenIds = new HashSet<Guid>();
 
             var results = request.Targets.Entities.Select(entity =>
             {
+                if (seenIds.Contains(entity.Id))
+                {
+                    throw new FaultException($"Duplicate Ids are not allowed in the Target list of an {nameof(UpsertMultipleRequest)}: {entity.Id}.");
+                }
+                seenIds.Add(entity.Id);
+
                 var upsertRequest = new UpsertRequest
                 {
                     Target = entity

--- a/src/XrmMockupShared/Requests/UpsertRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/UpsertRequestHandler.cs
@@ -12,7 +12,7 @@ using DG.Tools.XrmMockup.Database;
 
 namespace DG.Tools.XrmMockup {
     internal class UpsertRequestHandler : RequestHandler {
-        internal UpsertRequestHandler(Core core, XrmDb db, MetadataSkeleton metadata, Security security) : base(core, db, metadata, security, "Upsert") {}
+        internal UpsertRequestHandler(Core core, XrmDb db, MetadataSkeleton metadata, Security security) : base(core, db, metadata, security, nameof(EventOperation.Upsert)) {}
 
         internal override OrganizationResponse Execute(OrganizationRequest orgRequest, EntityReference userRef) {
             var request = MakeRequest<UpsertRequest>(orgRequest);

--- a/src/XrmMockupShared/Workflow/WorkflowManager.cs
+++ b/src/XrmMockupShared/Workflow/WorkflowManager.cs
@@ -75,7 +75,7 @@ namespace DG.Tools.XrmMockup {
         /// <param name="postImage"></param>
         /// <param name="pluginContext"></param>
         /// <param name="core"></param>
-        public void TriggerSync(string operation, ExecutionStage stage,
+        public void TriggerSync(EventOperation operation, ExecutionStage stage,
                 object entity, Entity preImage, Entity postImage, PluginContext pluginContext, Core core)
         {
             var toExecute = synchronousWorkflows.Where(x => ShouldExecute(x, operation, stage, entity, pluginContext)).ToList();
@@ -104,7 +104,7 @@ namespace DG.Tools.XrmMockup {
             }
         }
 
-        public void StageAsync(string operation, ExecutionStage stage,
+        public void StageAsync(EventOperation operation, ExecutionStage stage,
                 object entity, Entity preImage, Entity postImage, PluginContext pluginContext, Core core)
         {
             var toExecute = asynchronousWorkflows.Where(x => ShouldStage(x, operation, stage, entity, pluginContext)).ToList();
@@ -167,7 +167,7 @@ namespace DG.Tools.XrmMockup {
             return thisPluginContext;
         }
 
-        private void Stage(Entity workflow, string operation, ExecutionStage stage,
+        private void Stage(Entity workflow, EventOperation operation, ExecutionStage stage,
             object entityObject, PluginContext pluginContext)
         {
             if (workflow.LogicalName != "workflow") return;
@@ -181,9 +181,9 @@ namespace DG.Tools.XrmMockup {
 
             checkInfiniteRecursion(pluginContext);
 
-            var isCreate = operation == nameof(EventOperation.Create).ToLower();
-            var isUpdate = operation == nameof(EventOperation.Update).ToLower();
-            var isDelete = operation == nameof(EventOperation.Delete).ToLower();
+            var isCreate = operation == EventOperation.Create;
+            var isUpdate = operation == EventOperation.Update;
+            var isDelete = operation == EventOperation.Delete;
 
             if (!ShouldTriggerOnAction(isCreate, isUpdate, isDelete, workflow)) return;
             
@@ -217,7 +217,7 @@ namespace DG.Tools.XrmMockup {
             pendingAsyncWorkflows.Enqueue(new WorkflowExecutionContext(parsedWorkflow, thisPluginContext, new EntityReference(logicalName, guid)));
         }
 
-        private bool ShouldStage(Entity workflow, string operation, ExecutionStage stage,
+        private bool ShouldStage(Entity workflow, EventOperation operation, ExecutionStage stage,
             object entityObject, PluginContext pluginContext)
         {
             if (workflow.LogicalName != "workflow") return false;
@@ -231,9 +231,9 @@ namespace DG.Tools.XrmMockup {
 
             checkInfiniteRecursion(pluginContext);
 
-            var isCreate = operation == nameof(EventOperation.Create).ToLower();
-            var isUpdate = operation == nameof(EventOperation.Update).ToLower();
-            var isDelete = operation == nameof(EventOperation.Delete).ToLower();
+            var isCreate = operation == EventOperation.Create;
+            var isUpdate = operation == EventOperation.Update;
+            var isDelete = operation == EventOperation.Delete;
 
             if (!ShouldTriggerOnAction(isCreate, isUpdate, isDelete, workflow)) return false;
 
@@ -275,7 +275,7 @@ namespace DG.Tools.XrmMockup {
             return true;
         }
 
-        private bool ShouldExecute(Entity workflow, string operation, ExecutionStage stage, object entityObject, PluginContext pluginContext)
+        private bool ShouldExecute(Entity workflow, EventOperation operation, ExecutionStage stage, object entityObject, PluginContext pluginContext)
         {
             // Check if it is supposed to execute. Returns preemptively, if it should not.
             if (workflow.LogicalName != "workflow") return false;
@@ -289,9 +289,9 @@ namespace DG.Tools.XrmMockup {
 
             checkInfiniteRecursion(pluginContext);
 
-            var isCreate = operation.ToLower() == nameof(EventOperation.Create).ToString().ToLower();
-            var isUpdate = operation.ToLower() == nameof(EventOperation.Update).ToString().ToLower();
-            var isDelete = operation.ToLower() == nameof(EventOperation.Delete).ToString().ToLower();
+            var isCreate = operation == EventOperation.Create;
+            var isUpdate = operation == EventOperation.Update;
+            var isDelete = operation == EventOperation.Delete;
 
             if (!ShouldTriggerOnAction(isCreate, isUpdate, isDelete, workflow)) return false;
 
@@ -325,7 +325,7 @@ namespace DG.Tools.XrmMockup {
             return true;
         }
 
-        private void Execute(Entity workflow, string operation, object entityObject, Entity preImage, Entity postImage, PluginContext pluginContext, Core core)
+        private void Execute(Entity workflow, EventOperation operation, object entityObject, Entity preImage, Entity postImage, PluginContext pluginContext, Core core)
         {
             // Check if it is supposed to execute. Returns preemptively, if it should not.
             var entity = entityObject as Entity;
@@ -336,9 +336,9 @@ namespace DG.Tools.XrmMockup {
 
             checkInfiniteRecursion(pluginContext);
 
-            var isCreate = operation.ToLower() == nameof(EventOperation.Create).ToString().ToLower();
-            var isUpdate = operation.ToLower() == nameof(EventOperation.Update).ToString().ToLower();
-            var isDelete = operation.ToLower() == nameof(EventOperation.Delete).ToString().ToLower();
+            var isCreate = operation == EventOperation.Create;
+            var isUpdate = operation == EventOperation.Update;
+            var isDelete = operation == EventOperation.Delete;
 
             var triggerFields = new HashSet<string>();
             if (workflow.GetAttributeValue<string>("triggeronupdateattributelist") != null)

--- a/src/XrmMockupShared/XrmMockupShared.projitems
+++ b/src/XrmMockupShared/XrmMockupShared.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)MockupServiceAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Plugin\CustomApiManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Requests\CommitFileBlocksUploadRequestHandler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Requests\UpdateMultipleRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)requests\InstantiateTemplateRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Requests\UploadBlockRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Requests\InitializeFileBlocksUploadRequestHandler.cs" />
@@ -81,6 +82,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Requests\RetrieveMultipleRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Requests\UpdateRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Requests\CreateRequestHandler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Requests\CreateMultipleRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Requests\RequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\TableColumnDTO.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\TableDTO.cs" />

--- a/src/XrmMockupShared/XrmMockupShared.projitems
+++ b/src/XrmMockupShared/XrmMockupShared.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)MockupServiceAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Plugin\CustomApiManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Requests\CommitFileBlocksUploadRequestHandler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Requests\UpsertMultipleRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Requests\UpdateMultipleRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)requests\InstantiateTemplateRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Requests\UploadBlockRequestHandler.cs" />

--- a/tests/SharedPluginsAndCodeactivites/Plugin.cs
+++ b/tests/SharedPluginsAndCodeactivites/Plugin.cs
@@ -824,6 +824,7 @@
         UnlockInvoicePricing,
         UnlockSalesOrderPricing,
         Update,
+        UpdateMultiple,
         ValidateRecurrenceRule,
         Win
     }

--- a/tests/SharedPluginsAndCodeactivites/SetCityOnCreateUpdateMultiple.cs
+++ b/tests/SharedPluginsAndCodeactivites/SetCityOnCreateUpdateMultiple.cs
@@ -7,12 +7,17 @@ using Microsoft.Xrm.Sdk.Messages;
 
 namespace DG.Some.Namespace
 {
-    public class SetCityOnCreateMultiple : Plugin
+    public class SetCityOnCreateUpdateMultiple : Plugin
     {
-        public SetCityOnCreateMultiple() : base(typeof(SetCityOnCreateMultiple))
+        public SetCityOnCreateUpdateMultiple() : base(typeof(SetCityOnCreateUpdateMultiple))
         {
             RegisterPluginStep<Contact>(
                 EventOperation.CreateMultiple,
+                ExecutionStage.PreOperation,
+                Execute);
+
+            RegisterPluginStep<Contact>(
+                EventOperation.UpdateMultiple,
                 ExecutionStage.PreOperation,
                 Execute);
         }

--- a/tests/SharedPluginsAndCodeactivites/SetCountryOnCreateUpdate.cs
+++ b/tests/SharedPluginsAndCodeactivites/SetCountryOnCreateUpdate.cs
@@ -4,12 +4,17 @@ using Microsoft.Xrm.Sdk;
 
 namespace DG.Some.Namespace
 {
-    public class SetCountryOnCreate : Plugin
+    public class SetCountryOnCreateUpdate : Plugin
     {
-        public SetCountryOnCreate() : base(typeof(SetCountryOnCreate))
+        public SetCountryOnCreateUpdate() : base(typeof(SetCountryOnCreateUpdate))
         {
             RegisterPluginStep<Contact>(
                 EventOperation.Create,
+                ExecutionStage.PreOperation,
+                Execute);
+
+            RegisterPluginStep<Contact>(
+                EventOperation.Update,
                 ExecutionStage.PreOperation,
                 Execute);
         }

--- a/tests/SharedPluginsAndCodeactivites/SharedPluginsAndCodeactivites.projitems
+++ b/tests/SharedPluginsAndCodeactivites/SharedPluginsAndCodeactivites.projitems
@@ -10,7 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Closeincidentplugin.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)\SetCityOnCreateMultiple.cs" />
+    <Compile Include="..\SharedPluginsAndCodeactivites\SetCityOnCreateUpdateMultiple.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CreateAccountApi.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CustomAPI.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)IncidentDeleteAllRelatedResolutionsOnClose.cs" />
@@ -59,6 +59,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)OpportunityWinLose.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)PluginNonDaxif.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Plugin.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)SetCountryOnCreate.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)SetCountryOnCreateUpdate.cs" />
   </ItemGroup>
 </Project>

--- a/tests/XrmMockup365Test/TestUpdateMultipleRequestHandler.cs
+++ b/tests/XrmMockup365Test/TestUpdateMultipleRequestHandler.cs
@@ -14,11 +14,11 @@ namespace DG.XrmMockupTest
         [Fact]
         public void TestUpdateMultipleEntities()
         {
-            var contact1 = orgGodService.Create(new Contact { FirstName = "John", LastName = "Doe" });
-            var contact2 = orgGodService.Create(new Contact { FirstName = "Jane", LastName = "Doe" });
+            var contactId1 = orgGodService.Create(new Contact { FirstName = "John", LastName = "Doe" });
+            var contactId2 = orgGodService.Create(new Contact { FirstName = "Jane", LastName = "Doe" });
 
-            var updateContact1 = new Contact(contact1) { FirstName = "Johny" };
-            var updateContact2 = new Contact(contact2) { FirstName = "Janey" };
+            var updateContact1 = new Contact(contactId1) { FirstName = "Johny" };
+            var updateContact2 = new Contact(contactId2) { FirstName = "Janey" };
 
             var updateMultipleRequest = new UpdateMultipleRequest
             {
@@ -33,11 +33,34 @@ namespace DG.XrmMockupTest
 
             //Assert.Equal(2, response.Ids.Length);
 
-            var updatedContact1 = Contact.Retrieve(orgAdminService, contact1);
-            var updatedContact2 = Contact.Retrieve(orgAdminService, contact2);
+            var updatedContact1 = Contact.Retrieve(orgAdminService, contactId1);
+            var updatedContact2 = Contact.Retrieve(orgAdminService, contactId2);
 
             Assert.Equal(updateContact1.FirstName, updatedContact1.FirstName);
             Assert.Equal(updateContact2.FirstName, updatedContact2.FirstName);
+        }
+
+        [Fact]
+        public void TestUpdateMultipleSameKeyIgnoresSubsequent()
+        {
+            var contactId = orgGodService.Create(new Contact { FirstName = "John", LastName = "Doe" });
+
+            var updateContact1 = new Contact(contactId) { FirstName = "Johny" };
+            var updateContact2 = new Contact(contactId) { FirstName = "Janey" };
+
+            var updateMultipleRequest = new UpdateMultipleRequest
+            {
+                Targets = new EntityCollection
+                {
+                    EntityName = Contact.EntityLogicalName,
+                    Entities = { updateContact1, updateContact2 }
+                }
+            };
+
+            var response = (UpdateMultipleResponse)orgAdminService.Execute(updateMultipleRequest);
+
+            var updatedContact = Contact.Retrieve(orgAdminService, contactId);
+            Assert.Equal(updateContact1.FirstName, updatedContact.FirstName);
         }
     }
 }

--- a/tests/XrmMockup365Test/TestUpdateMultipleRequestHandler.cs
+++ b/tests/XrmMockup365Test/TestUpdateMultipleRequestHandler.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using DG.XrmFramework.BusinessDomain.ServiceContext;
+using Xunit;
+
+namespace DG.XrmMockupTest
+{
+    public class TestUpdateMultipleRequestHandler : UnitTestBase
+    {
+        public TestUpdateMultipleRequestHandler(XrmMockupFixture fixture) : base(fixture) { }
+
+        [Fact]
+        public void TestUpdateMultipleEntities()
+        {
+            var contact1 = orgGodService.Create(new Contact { FirstName = "John", LastName = "Doe" });
+            var contact2 = orgGodService.Create(new Contact { FirstName = "Jane", LastName = "Doe" });
+
+            var updateContact1 = new Contact(contact1) { FirstName = "Johny" };
+            var updateContact2 = new Contact(contact2) { FirstName = "Janey" };
+
+            var updateMultipleRequest = new UpdateMultipleRequest
+            {
+                Targets = new EntityCollection
+                {
+                    EntityName = Contact.EntityLogicalName,
+                    Entities = { updateContact1, updateContact2 }
+                }
+            };
+
+            var response = (UpdateMultipleResponse)orgAdminService.Execute(updateMultipleRequest);
+
+            //Assert.Equal(2, response.Ids.Length);
+
+            var updatedContact1 = Contact.Retrieve(orgAdminService, contact1);
+            var updatedContact2 = Contact.Retrieve(orgAdminService, contact2);
+
+            Assert.Equal(updateContact1.FirstName, updatedContact1.FirstName);
+            Assert.Equal(updateContact2.FirstName, updatedContact2.FirstName);
+        }
+    }
+}

--- a/tests/XrmMockup365Test/TestUpdateMultipleRequestPlugin.cs
+++ b/tests/XrmMockup365Test/TestUpdateMultipleRequestPlugin.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using DG.XrmFramework.BusinessDomain.ServiceContext;
+using Xunit;
+
+namespace DG.XrmMockupTest
+{
+    public class TestUpdateMultipleRequestPlugin : UnitTestBase
+    {
+        public TestUpdateMultipleRequestPlugin(XrmMockupFixture fixture) : base(fixture) { }
+
+        [Fact]
+        public void TestUpdateMultipleEntitiesPlugin_UpdateMultiple()
+        {
+            var contact1 = orgGodService.Create(new Contact { Address2_City = "Texas", Address2_Country = "USA" });
+            var contact2 = orgGodService.Create(new Contact { Address2_City = "Nuuk", Address2_Country = "Greenland" });
+
+            var updateContact1 = new Contact(contact1) { Address2_City = "Houston" };
+            var updateContact2 = new Contact(contact2) { Address2_City = "Sisimiut" };
+
+            var updateMultipleRequest = new UpdateMultipleRequest()
+            {
+                Targets = new EntityCollection() {
+                    EntityName = Contact.EntityLogicalName,
+                    Entities = { updateContact1, updateContact2 }
+                }
+            };
+
+            var response = (UpdateMultipleResponse)orgAdminService.Execute(updateMultipleRequest);
+
+            var createdContact1 = Contact.Retrieve(orgAdminService, contact1);
+            var createdContact2 = Contact.Retrieve(orgAdminService, contact2);
+
+            Assert.Equal("Copenhagen", createdContact1.Address2_City);
+            Assert.Equal("Denmark", createdContact1.Address2_Country);
+
+            Assert.Equal("Copenhagen", createdContact2.Address2_City);
+            Assert.Equal("Denmark", createdContact2.Address2_Country);
+        }
+
+        [Fact]
+        public void TestUpdateMultipleEntitiesPlugin_Update()
+        {
+            var contact = new Contact { Address2_City = "Texas", Address2_Country = "USA" };
+            contact.Id = orgGodService.Create(contact);
+
+            orgAdminService.Update(new Contact(contact.Id)
+            {
+                FirstName = "John",
+                LastName = "Lennon"
+            });
+            var retrievedContact = Contact.Retrieve(orgAdminService, contact.Id);
+
+            Assert.Equal("Copenhagen", retrievedContact.Address2_City);
+            Assert.Equal("Denmark", retrievedContact.Address2_Country);
+        }
+    }
+}

--- a/tests/XrmMockup365Test/TestUpsertMultiple.cs
+++ b/tests/XrmMockup365Test/TestUpsertMultiple.cs
@@ -1,0 +1,56 @@
+﻿using System.Linq;
+using Microsoft.Xrm.Sdk.Messages;
+using DG.XrmFramework.BusinessDomain.ServiceContext;
+using Xunit;
+
+namespace DG.XrmMockupTest
+{
+    public class TestUpsertMultiple : UnitTestBase
+    {
+        public TestUpsertMultiple(XrmMockupFixture fixture) : base(fixture) { }
+
+        [Fact]
+        public void TestUpsertMultipleAll()
+        {
+            throw new System.NotImplementedException();
+            //using (var context = new Xrm(orgAdminUIService))
+            //{
+            //    var account1 = new Account { Name = "Account 1" };
+            //    var account2 = new Account { Name = "Account 2" };
+
+            //    var _account1id = orgAdminUIService.Create(account1);
+            //    Assert.Single(
+            //         context.AccountSet
+            //         .Where(x => x.Name.StartsWith("Account"))
+            //         .ToList()
+            //     );
+            //    Assert.Equal("Account 1", context.AccountSet.First().Name);
+
+            //    var bla = Account.Retrieve_dg_name(orgAdminUIService, "Account 2");
+
+            //    context.ClearChanges();
+            //    var req = new UpsertRequest
+            //    {
+            //        Target = new Account { Name = "New Account 1", Id = _account1id }
+            //    };
+            //    var resp = orgAdminUIService.Execute(req) as UpsertResponse;
+            //    Assert.False(resp.RecordCreated);
+            //    Assert.Single(
+            //         context.AccountSet
+            //         .Where(x => x.Name.StartsWith("New Account"))
+            //         .ToList());
+            //    Assert.Equal("New Account 1", context.AccountSet.First().Name);
+
+            //    context.ClearChanges();
+            //    req.Target = account2;
+            //    resp = orgAdminUIService.Execute(req) as UpsertResponse;
+            //    Assert.True(resp.RecordCreated);
+            //    Assert.Equal(2, context.AccountSet.AsEnumerable().Where(
+            //         x => x.Name.StartsWith("Account") || x.Name.StartsWith("New Account")).Count());
+
+
+            //}
+        }
+    }
+
+}

--- a/tests/XrmMockup365Test/TestUpsertMultiple.cs
+++ b/tests/XrmMockup365Test/TestUpsertMultiple.cs
@@ -2,6 +2,7 @@
 using Microsoft.Xrm.Sdk.Messages;
 using DG.XrmFramework.BusinessDomain.ServiceContext;
 using Xunit;
+using Microsoft.Xrm.Sdk;
 
 namespace DG.XrmMockupTest
 {
@@ -12,45 +13,50 @@ namespace DG.XrmMockupTest
         [Fact]
         public void TestUpsertMultipleAll()
         {
-            throw new System.NotImplementedException();
-            //using (var context = new Xrm(orgAdminUIService))
-            //{
-            //    var account1 = new Account { Name = "Account 1" };
-            //    var account2 = new Account { Name = "Account 2" };
+            using (var context = new Xrm(orgAdminUIService))
+            {
+                var account1 = new Account { Name = "Account 1" };
 
-            //    var _account1id = orgAdminUIService.Create(account1);
-            //    Assert.Single(
-            //         context.AccountSet
-            //         .Where(x => x.Name.StartsWith("Account"))
-            //         .ToList()
-            //     );
-            //    Assert.Equal("Account 1", context.AccountSet.First().Name);
+                var _account1id = orgAdminUIService.Create(account1);
+                Assert.Single(
+                     context.AccountSet
+                     .Where(x => x.Name.StartsWith("Account"))
+                     .ToList()
+                 );
+                Assert.Equal("Account 1", context.AccountSet.First().Name);
 
-            //    var bla = Account.Retrieve_dg_name(orgAdminUIService, "Account 2");
+                var bla = Account.Retrieve_dg_name(orgAdminUIService, "Account 2");
 
-            //    context.ClearChanges();
-            //    var req = new UpsertRequest
-            //    {
-            //        Target = new Account { Name = "New Account 1", Id = _account1id }
-            //    };
-            //    var resp = orgAdminUIService.Execute(req) as UpsertResponse;
-            //    Assert.False(resp.RecordCreated);
-            //    Assert.Single(
-            //         context.AccountSet
-            //         .Where(x => x.Name.StartsWith("New Account"))
-            //         .ToList());
-            //    Assert.Equal("New Account 1", context.AccountSet.First().Name);
+                context.ClearChanges();
 
-            //    context.ClearChanges();
-            //    req.Target = account2;
-            //    resp = orgAdminUIService.Execute(req) as UpsertResponse;
-            //    Assert.True(resp.RecordCreated);
-            //    Assert.Equal(2, context.AccountSet.AsEnumerable().Where(
-            //         x => x.Name.StartsWith("Account") || x.Name.StartsWith("New Account")).Count());
+                var req = new UpsertMultipleRequest
+                {
+                    Targets = new EntityCollection
+                    {
+                        EntityName = Account.EntityLogicalName,
+                        Entities = {
+                            new Account(_account1id)
+                            {
+                                Name = "New Account 1"
+                            },
+                            new Account { Name = "Account 2" }
+                        }
+                    }
+                };
 
+                var resp = orgAdminUIService.Execute(req) as UpsertMultipleResponse;
 
-            //}
+                Assert.Collection(resp.Results,
+                    r => Assert.False(r.RecordCreated),
+                    r => Assert.True(r.RecordCreated)
+                );
+
+                Assert.Equal(2, context.AccountSet.AsEnumerable()
+                    .Count(x => x.Name.StartsWith("Account") || x.Name.StartsWith("New Account")));
+
+                Assert.Equal("New Account 1", context.AccountSet.First().Name);
+                Assert.Equal("Account 2", context.AccountSet.Skip(1).First().Name);
+            }
         }
     }
-
 }


### PR DESCRIPTION
This pull request includes several changes to add new request handlers, and improve the codebase by refining existing logic and adding new mappings. The most important changes include adding new request handlers, and refining logic for event operations.

### Request Handlers:
* [`src/XrmMockupShared/Core.cs`](diffhunk://#diff-292f698c02eeed504ced46ef567bc0d2588d52523bbb5d73bb44ca70cad03760R218-R219): Added `UpdateMultipleRequestHandler` and `UpsertMultipleRequestHandler` in the `InitializeDB` method.

### Codebase Refinements:
* [`src/XrmMockupShared/Core.cs`](diffhunk://#diff-292f698c02eeed504ced46ef567bc0d2588d52523bbb5d73bb44ca70cad03760L593-R595): Refined logic in the `Execute` method to use `EventOperation` type and added checks for `shouldTrigger` and `eventOp` being `EventOperation`. [[1]](diffhunk://#diff-292f698c02eeed504ced46ef567bc0d2588d52523bbb5d73bb44ca70cad03760L593-R595) [[2]](diffhunk://#diff-292f698c02eeed504ced46ef567bc0d2588d52523bbb5d73bb44ca70cad03760R610-R654) [[3]](diffhunk://#diff-292f698c02eeed504ced46ef567bc0d2588d52523bbb5d73bb44ca70cad03760L660-R685)
* [`src/XrmMockupShared/Database/XrmDb.cs`](diffhunk://#diff-249b98afaad5c942418546360c35c1326c0528de9ff949da58bf9b9eab69331bL186-R186): Added a check for `reference?.Id != default` in the `TryGetDbRow` method.
* [`src/XrmMockupShared/Plugin/PluginContext.cs`](diffhunk://#diff-c472242a3040c10830b4a4d0b49103625254e95fcf69926189a707816fda4c32L213-R216): Improved `PrimaryEntityId` property getter to handle null values safely.

### Mappings and Enums:
* [`src/XrmMockupShared/Domain.cs`](diffhunk://#diff-dced3c866e6f0d110e477ed6009a9d68809ea790a78f077038781207383d2adeR146-R148): Added `UpdateMultiple`, `Upsert`, and `UpsertMultiple` to the `EventOperation` enum.
* [`src/XrmMockupShared/Mappings.cs`](diffhunk://#diff-bdbd00f0652c01063450dd959a1cd6f42286718ebbafc762147333b5e70279bcR7): Updated `EntityImageProperty` and `RequestToEventOperation` dictionaries to use `nameof` and `EventOperation` type respectively, and added new mappings for multiple request types. [[1]](diffhunk://#diff-bdbd00f0652c01063450dd959a1cd6f42286718ebbafc762147333b5e70279bcR7) [[2]](diffhunk://#diff-bdbd00f0652c01063450dd959a1cd6f42286718ebbafc762147333b5e70279bcL15-R80) [[3]](diffhunk://#diff-bdbd00f0652c01063450dd959a1cd6f42286718ebbafc762147333b5e70279bcR157-R158) [[4]](diffhunk://#diff-bdbd00f0652c01063450dd959a1cd6f42286718ebbafc762147333b5e70279bcL151-L152)