### PR TITLE
Updated targets to codeanalysis to be more modern. 

### DIFF
--- a/src/XrmMockup365/XrmMockup365.csproj
+++ b/src/XrmMockup365/XrmMockup365.csproj
@@ -76,6 +76,8 @@
 	<ItemGroup Condition="'$(TargetFramework)' != 'net462'">
 		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.3" />
 		<PackageReference Include="UiPath.Workflow" Version="6.0.3" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="4.8.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.8.0" />
 	</ItemGroup>
 	<ItemGroup>
 		<Compile Include="..\XrmMockupShared\Requests\CreateMultipleRequestHandler.cs" />


### PR DESCRIPTION
Previously prevented .net8 projects to use code analysis because UiPath.Workflow defaulted to 4.0.1