### PR TITLE
Throw better exception when attempting to format an invalid OptionSet value

### DIFF
--- a/src/XrmMockupShared/Requests/RetrieveMultipleRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/RetrieveMultipleRequestHandler.cs
@@ -77,7 +77,7 @@ namespace DG.Tools.XrmMockup
                         {
                             if (security.HasPermission(m, AccessRights.ReadAccess, userRef))
                             {
-                                Utility.SetFormmattedValues(db, m, entityMetadata);
+                                Utility.SetFormattedValues(db, m, entityMetadata);
                                 collection.Add(new KeyValuePair<DbRow, Entity>(row, m));
                             }
                         });
@@ -87,7 +87,7 @@ namespace DG.Tools.XrmMockup
                 {
                     if (security.HasPermission(toAdd, AccessRights.ReadAccess, userRef))
                     {
-                        Utility.SetFormmattedValues(db, toAdd, entityMetadata);
+                        Utility.SetFormattedValues(db, toAdd, entityMetadata);
                         collection.Add(new KeyValuePair<DbRow, Entity>(row, toAdd));
                     }
                 }

--- a/src/XrmMockupShared/Requests/RetrieveRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/RetrieveRequestHandler.cs
@@ -39,7 +39,7 @@ namespace DG.Tools.XrmMockup {
             row = db.GetDbRow(request.Target);
             var entity = core.GetStronglyTypedEntity(row.ToEntity(), row.Metadata, request.ColumnSet);
 
-            Utility.SetFormmattedValues(db, entity, row.Metadata);
+            Utility.SetFormattedValues(db, entity, row.Metadata);
 
             if (!settings.SetUnsettableFields) {
                 Utility.RemoveUnsettableAttributes("Retrieve", row.Metadata, entity);


### PR DESCRIPTION
If the value was invalid (e.g. a stray 0 instead of an existing value), it would throw an opaque NullReferenceException from inside mockup, which could be hard to track down.

Now throws an exception detailing which value is wrong and where.