### PR TITLE
Fix ordering regression

### DIFF
--- a/src/XrmMockupShared/Requests/RetrieveMultipleRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/RetrieveMultipleRequestHandler.cs
@@ -103,7 +103,7 @@ namespace DG.Tools.XrmMockup
             }
             else
             {
-                Func<KeyValuePair<DbRow, Entity>, object> selector = x => { return x.Value.Attributes.TryGetValue(orders[0].AttributeName, out var a) ? Utility.GetComparableAttribute(a) : null; };
+                Func<KeyValuePair<DbRow, Entity>, object> selector = x => x.Value.Attributes.TryGetValue(orders[0].AttributeName, out var a) ? Utility.GetComparableAttribute(a) : null;
                 if (orders.First().OrderType == OrderType.Ascending)
                     tempSortedList = collection.OrderBy(selector);
                 else
@@ -111,7 +111,7 @@ namespace DG.Tools.XrmMockup
 
                 foreach (var order in orders.Skip(1))
                 {
-                    selector = (x => { return x.Value.Attributes.TryGetValue(order.AttributeName, out var a) ? Utility.GetComparableAttribute(a) : null; });
+                    selector = (x => x.Value.Attributes.TryGetValue(order.AttributeName, out var a) ? Utility.GetComparableAttribute(a) : null);
                     if (order.OrderType == OrderType.Ascending)
                         tempSortedList = tempSortedList.ThenBy(selector);
                     else
@@ -121,9 +121,9 @@ namespace DG.Tools.XrmMockup
                 tempSortedList = tempSortedList.ThenBy(x => x.Key.Sequence);
             }
 
-            var entitiesToReturn = RefineEntityAttributes(
-                tempSortedList.Any() ? tempSortedList.Select(x => x.Value) : collection.Select(x => x.Value),
-                queryExpr.ColumnSet);
+            // Convert to array to lock-in the ordering (if we are ordering by something that doesn't exist in the columnset, the ordering will fail afterwards)
+            var orderedEntities = tempSortedList.Select(x => x.Value).ToArray();
+            var entitiesToReturn = RefineEntityAttributes(orderedEntities, queryExpr.ColumnSet);
 
             if (queryExpr.Distinct)
             {

--- a/tests/SharedTests/TestRetrieveMultiple.cs
+++ b/tests/SharedTests/TestRetrieveMultiple.cs
@@ -478,6 +478,47 @@ namespace DG.XrmMockupTest
         }
 
         [Fact]
+        public void TestOrderByLambdaSyntax()
+        {
+            orgAdminService.Update(new Account(account1.Id) { NumberOfEmployees = 10 });
+            orgAdminService.Update(new Account(account2.Id) { NumberOfEmployees = 20 });
+
+            using (var context = new Xrm(orgAdminUIService))
+            {
+                var query = context.AccountSet
+                        .Where(acc => acc.Address1_City == "Virum")
+                        .OrderBy(acc => acc.NumberOfEmployees)
+                        .Select(acc => new { acc.AccountId });
+
+                var result = query.ToArray();
+                Assert.Equal(2, result.Length);
+                Assert.Equal(account1.Id, result[0].AccountId);
+                Assert.Equal(account2.Id, result[1].AccountId);
+            }
+        }
+
+        [Fact]
+        public void TestOrderByDescendingLambdaSyntax()
+        {
+            orgAdminService.Update(new Account(account1.Id) { NumberOfEmployees = 10 });
+            orgAdminService.Update(new Account(account2.Id) { NumberOfEmployees = 20 });
+
+            using (var context = new Xrm(orgAdminUIService))
+            {
+                var query = context.AccountSet
+                        .Where(acc => acc.Address1_City == "Virum")
+                        .OrderByDescending(acc => acc.NumberOfEmployees)
+                        .Select(acc => new { acc.AccountId });
+
+                var result = query.ToArray();
+                Assert.Equal(2, result.Length);
+                Assert.Equal(account2.Id, result[0].AccountId);
+                Assert.Equal(account1.Id, result[1].AccountId);
+            }
+        }
+
+
+        [Fact]
         public void RetrieveMultipleNotEqualsNullCheck()
         {
             using (var context = new Xrm(orgAdminUIService))


### PR DESCRIPTION
Fix: When not returning the attributes that are being used for ordering, they get evaluated AFTER they have been removed, thus ruining the ordering