### PR TITLE
Added support for evaluating PowerFx backed Formula fields

### DIFF
--- a/src/XrmMockup365/XrmMockup365.csproj
+++ b/src/XrmMockup365/XrmMockup365.csproj
@@ -77,6 +77,9 @@
 		<PackageReference Include="Microsoft.PowerPlatform.Dataverse.Client" Version="1.2.3" />
 		<PackageReference Include="UiPath.Workflow" Version="6.0.3" />
 	</ItemGroup>
+	<ItemGroup>
+        <PackageReference Include="Microsoft.PowerFx.Dataverse.Eval" Version="1.2.0-build.20231002-1005" />
+	</ItemGroup>
     <Import Project="..\XrmMockupShared\XrmMockupShared.projitems" Label="Shared" />
     <Import Project="..\XrmMockupWorkflow\XrmMockupWorkflow.projitems" Label="Shared" />
     <Import Project="..\MetadataSkeleton\MetadataSkeleton.projitems" Label="Shared" />

--- a/src/XrmMockupShared/Core.cs
+++ b/src/XrmMockupShared/Core.cs
@@ -1159,15 +1159,17 @@ namespace DG.Tools.XrmMockup
             foreach (var attr in attributes)
             {
                 var definition = Utility.GetFormulaDefinition(attr, SourceType.CalculatedAttribute);
+
                 if (definition == null)
                 {
-                    var trace = this.ServiceFactory.GetService<ITracingService>();
+                    var trace = ServiceFactory.GetService<ITracingService>();
                     trace.Trace($"Calculated field on {attr.EntityLogicalName} field {attr.LogicalName} is empty");
-                    return;
+                    continue;
                 }
+
                 var tree = WorkflowConstructor.ParseCalculated(definition);
-                var factory = this.ServiceFactory;
-                tree.Execute(row.ToEntity().CloneEntity(row.Metadata, new ColumnSet(true)), this.TimeOffset, this.GetWorkflowService(),
+                var factory = ServiceFactory;
+                tree.Execute(row.ToEntity().CloneEntity(row.Metadata, new ColumnSet(true)), TimeOffset, GetWorkflowService(),
                     factory, factory.GetService<ITracingService>());
             }
         }
@@ -1178,11 +1180,12 @@ namespace DG.Tools.XrmMockup
             foreach (var attr in attributes)
             {
                 var definition = Utility.GetFormulaDefinition(attr, SourceType.FormulaAttribute);
+
                 if (definition == null)
                 {
                     var trace = ServiceFactory.GetService<ITracingService>();
                     trace.Trace($"Formula field on {attr.EntityLogicalName} field {attr.LogicalName} is empty");
-                    return;
+                    continue;
                 }
 
                 entity[attr.LogicalName] = await FormulaFieldEvaluator.Evaluate(definition, entity);

--- a/src/XrmMockupShared/Core.cs
+++ b/src/XrmMockupShared/Core.cs
@@ -66,6 +66,8 @@ namespace DG.Tools.XrmMockup
         public MockupServiceProviderAndFactory ServiceFactory { get; }
         public ITracingServiceFactory TracingServiceFactory { get; }
 
+        private FormulaFieldEvaluator FormulaFieldEvaluator { get; }
+
         private List<string> systemAttributeNames;
 
         public EntityReference AdminUserRef;
@@ -123,6 +125,8 @@ namespace DG.Tools.XrmMockup
             InitializeDB();
             this.security.InitializeSecurityRoles(db);
             this.orgDetail = settings.OrganizationDetail;
+
+            this.FormulaFieldEvaluator = new FormulaFieldEvaluator(ServiceFactory);
         }
 
         private void InitializeDB()
@@ -208,6 +212,7 @@ namespace DG.Tools.XrmMockup
             new UpsertRequestHandler(this, db, metadata, security),
             new RetrieveAttributeRequestHandler(this, db, metadata, security),
             new WhoAmIRequestHandler(this, db, metadata, security),
+            new RetrieveAllEntitiesRequestHandler(this, db, metadata, security),
             new RetrievePrincipalAccessRequestHandler(this, db, metadata, security),
             new RetrieveMetadataChangesRequestHandler(this, db, metadata, security),
             new InitializeFileBlocksUploadRequestHandler(this, db, metadata, security),
@@ -1149,19 +1154,11 @@ namespace DG.Tools.XrmMockup
         internal void ExecuteCalculatedFields(DbRow row)
         {
             var attributes = row.Metadata.Attributes.Where(
-                m => m.SourceType == 1 && !(m is MoneyAttributeMetadata && m.LogicalName.EndsWith("_base")));
+                m => m.SourceType == (int)SourceType.CalculatedAttribute && !(m is MoneyAttributeMetadata && m.LogicalName.EndsWith("_base")));
 
             foreach (var attr in attributes)
             {
-                string definition = (attr as BooleanAttributeMetadata)?.FormulaDefinition;
-                if (attr is BooleanAttributeMetadata) definition = (attr as BooleanAttributeMetadata).FormulaDefinition;
-                else if (attr is DateTimeAttributeMetadata) definition = (attr as DateTimeAttributeMetadata).FormulaDefinition;
-                else if (attr is DecimalAttributeMetadata) definition = (attr as DecimalAttributeMetadata).FormulaDefinition;
-                else if (attr is IntegerAttributeMetadata) definition = (attr as IntegerAttributeMetadata).FormulaDefinition;
-                else if (attr is MoneyAttributeMetadata) definition = (attr as MoneyAttributeMetadata).FormulaDefinition;
-                else if (attr is PicklistAttributeMetadata) definition = (attr as PicklistAttributeMetadata).FormulaDefinition;
-                else if (attr is StringAttributeMetadata) definition = (attr as StringAttributeMetadata).FormulaDefinition;
-
+                var definition = Utility.GetFormulaDefinition(attr, SourceType.CalculatedAttribute);
                 if (definition == null)
                 {
                     var trace = this.ServiceFactory.GetService<ITracingService>();
@@ -1172,6 +1169,23 @@ namespace DG.Tools.XrmMockup
                 var factory = this.ServiceFactory;
                 tree.Execute(row.ToEntity().CloneEntity(row.Metadata, new ColumnSet(true)), this.TimeOffset, this.GetWorkflowService(),
                     factory, factory.GetService<ITracingService>());
+            }
+        }
+
+        internal async System.Threading.Tasks.Task ExecuteFormulaFields(EntityMetadata entityMetadata, Entity entity)
+        {
+            var attributes = entityMetadata.Attributes.Where(m => m.SourceType == (int)SourceType.FormulaAttribute);
+            foreach (var attr in attributes)
+            {
+                var definition = Utility.GetFormulaDefinition(attr, SourceType.FormulaAttribute);
+                if (definition == null)
+                {
+                    var trace = ServiceFactory.GetService<ITracingService>();
+                    trace.Trace($"Formula field on {attr.EntityLogicalName} field {attr.LogicalName} is empty");
+                    return;
+                }
+
+                entity[attr.LogicalName] = await FormulaFieldEvaluator.Evaluate(definition, entity);
             }
         }
 

--- a/src/XrmMockupShared/Domain.cs
+++ b/src/XrmMockupShared/Domain.cs
@@ -155,4 +155,12 @@ namespace DG.Tools.XrmMockup {
         PostImage = 1,
         Both = 2,
     }
+
+    internal enum SourceType
+    {
+        SimpleAttribute = 0,
+        CalculatedAttribute = 1,
+        RollupAttribute = 2,
+        FormulaAttribute = 3
+    }
 }

--- a/src/XrmMockupShared/FormulaFieldEvaluator.cs
+++ b/src/XrmMockupShared/FormulaFieldEvaluator.cs
@@ -1,0 +1,40 @@
+using Microsoft.PowerFx.Dataverse;
+using Microsoft.PowerFx;
+using Microsoft.Xrm.Sdk;
+using System.Threading.Tasks;
+using System.Threading;
+using System.Globalization;
+
+namespace DG.Tools.XrmMockup
+{
+    internal class FormulaFieldEvaluator
+    {
+        private readonly IOrganizationService _organizationService;
+        private readonly DataverseConnection _dataverseConnection;
+
+        public FormulaFieldEvaluator(IOrganizationServiceFactory serviceFactory)
+        {
+            _organizationService = serviceFactory.CreateOrganizationService(null);
+            _dataverseConnection = SingleOrgPolicy.New(_organizationService);
+        }
+
+        public async Task<object> Evaluate(string formula, Entity thisEntity)
+        {
+            var rowScopeSymbols = _dataverseConnection.GetRowScopeSymbols(thisEntity.LogicalName, true);
+
+            var engine = new RecalcEngine();
+            var combinedSymbols = ReadOnlySymbolTable.Compose(rowScopeSymbols, _dataverseConnection.Symbols);
+            var checkResult = engine.Check(formula, new ParserOptions(CultureInfo.InvariantCulture), combinedSymbols);
+            checkResult.ThrowOnErrors();
+
+            var thisRecord = _dataverseConnection.Marshal(thisEntity);
+            var rowScopeValues = ReadOnlySymbolValues.Compose(
+                ReadOnlySymbolValues.NewFromRecord(rowScopeSymbols, thisRecord),
+                _dataverseConnection.SymbolValues
+            );
+
+            var computedValue = await checkResult.GetEvaluator().EvalAsync(CancellationToken.None, new RuntimeConfig(rowScopeValues));
+            return computedValue.ToObject();
+        }
+    }
+}

--- a/src/XrmMockupShared/Requests/CalculateRollupFieldRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/CalculateRollupFieldRequestHandler.cs
@@ -1,13 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.Xrm.Sdk;
-using Microsoft.Xrm.Sdk.Messages;
-using Microsoft.Xrm.Sdk.Query;
+﻿using Microsoft.Xrm.Sdk;
 using System.Linq;
 using Microsoft.Crm.Sdk.Messages;
 using System.ServiceModel;
-using Microsoft.Xrm.Sdk.Metadata;
 using DG.Tools.XrmMockup.Database;
 using WorkflowExecuter;
 
@@ -24,25 +18,22 @@ namespace DG.Tools.XrmMockup {
             var field = metadata.Attributes.FirstOrDefault(a => a.LogicalName == request.FieldName);
             if (field == null) {
                 throw new FaultException($"Couldn't find the field '{request.FieldName}' on the entity '{dbEntity.LogicalName}'");
-            } else {
-                string definition = (field as BooleanAttributeMetadata)?.FormulaDefinition;
-                if ((field as BooleanAttributeMetadata)?.SourceType == 2) definition = (field as BooleanAttributeMetadata).FormulaDefinition;
-                else if ((field as DateTimeAttributeMetadata)?.SourceType == 2) definition = (field as DateTimeAttributeMetadata).FormulaDefinition;
-                else if ((field as DecimalAttributeMetadata)?.SourceType == 2) definition = (field as DecimalAttributeMetadata).FormulaDefinition;
-                else if ((field as IntegerAttributeMetadata)?.SourceType == 2) definition = (field as IntegerAttributeMetadata).FormulaDefinition;
-                else if ((field as MoneyAttributeMetadata)?.SourceType == 2) definition = (field as MoneyAttributeMetadata).FormulaDefinition;
-                else if ((field as PicklistAttributeMetadata)?.SourceType == 2) definition = (field as PicklistAttributeMetadata).FormulaDefinition;
-                else if ((field as StringAttributeMetadata)?.SourceType == 2) definition = (field as StringAttributeMetadata).FormulaDefinition;
-
-                if (definition == null) {
+            } else
+            {
+                var definition = Utility.GetFormulaDefinition(field, SourceType.RollupAttribute);
+                if (definition == null)
+                {
                     throw new FaultException($"Field '{request.FieldName}' on entity '{dbEntity.LogicalName}' is not a rollup field");
-                } else {
+                }
+                else
+                {
                     var tree = WorkflowConstructor.ParseRollUp(definition);
                     var factory = core.ServiceFactory;
                     var resultTree = tree.Execute(dbEntity, core.TimeOffset, core.GetWorkflowService(), factory, factory.GetService<ITracingService>());
                     var resultLocaltion = ((resultTree.StartActivity as RollUp).Aggregation[1] as Aggregate).VariableName;
                     var result = resultTree.Variables[resultLocaltion];
-                    if (result != null) {
+                    if (result != null)
+                    {
                         dbEntity[request.FieldName] = result;
                     }
                 }

--- a/src/XrmMockupShared/Requests/RetrieveAllEntitiesRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/RetrieveAllEntitiesRequestHandler.cs
@@ -1,0 +1,23 @@
+using Microsoft.Xrm.Sdk;
+using System.Linq;
+using DG.Tools.XrmMockup.Database;
+using Microsoft.Xrm.Sdk.Messages;
+
+namespace DG.Tools.XrmMockup
+{
+    internal class RetrieveAllEntitiesRequestHandler : RequestHandler
+    {
+        internal RetrieveAllEntitiesRequestHandler(Core core, XrmDb db, MetadataSkeleton metadata, Security security) : base(core, db, metadata, security, "RetrieveAllEntities") { }
+
+        internal override OrganizationResponse Execute(OrganizationRequest orgRequest, EntityReference userRef)
+        {
+            var request = MakeRequest<RetrieveAllEntitiesRequest>(orgRequest);
+
+            var response = new RetrieveAllEntitiesResponse();
+            response.Results["EntityMetadata"] = metadata.EntityMetadata.Values
+                .Select(entityMetadata => RetrieveEntityRequestHandler.FilterEntityMetadataProperties(entityMetadata, request.EntityFilters)).ToArray();
+
+            return response;
+        }
+    }
+}

--- a/src/XrmMockupShared/Requests/RetrieveEntityRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/RetrieveEntityRequestHandler.cs
@@ -1,11 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Text;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Messages;
-using Microsoft.Xrm.Sdk.Query;
 using System.Linq;
-using Microsoft.Crm.Sdk.Messages;
 using System.ServiceModel;
 using Microsoft.Xrm.Sdk.Metadata;
 using DG.Tools.XrmMockup.Database;
@@ -45,7 +42,7 @@ namespace DG.Tools.XrmMockup
             return resp;
         }
 
-        private static EntityMetadata FilterEntityMetadataProperties(EntityMetadata metadata, EntityFilters entityFilters)
+        public static EntityMetadata FilterEntityMetadataProperties(EntityMetadata metadata, EntityFilters entityFilters)
         {
             var propsToRemove = new List<string>();
             var privilegesProps = new List<string>() { "Privileges" };

--- a/src/XrmMockupShared/Requests/RetrieveMultipleRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/RetrieveMultipleRequestHandler.cs
@@ -55,6 +55,7 @@ namespace DG.Tools.XrmMockup
             {
                 core.ExecuteCalculatedFields(row);
             }
+
             //get the rows again to include the calulated values
             rows = db.GetDBEntityRows(queryExpr.EntityName);
 
@@ -123,6 +124,11 @@ namespace DG.Tools.XrmMockup
 
             // Convert to array to lock-in the ordering (if we are ordering by something that doesn't exist in the columnset, the ordering will fail afterwards)
             var orderedEntities = tempSortedList.Select(x => x.Value).ToArray();
+
+            // Calculate formula fields before we filter the fetched columns
+            Parallel.ForEach(orderedEntities, entity => core.ExecuteFormulaFields(entityMetadata, entity).GetAwaiter().GetResult());
+
+            // Refine and filter the columns
             var entitiesToReturn = RefineEntityAttributes(orderedEntities, queryExpr.ColumnSet);
 
             if (queryExpr.Distinct)

--- a/src/XrmMockupShared/Requests/RetrieveRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/RetrieveRequestHandler.cs
@@ -36,8 +36,14 @@ namespace DG.Tools.XrmMockup {
             }
 
             core.ExecuteCalculatedFields(row);
+
             row = db.GetDbRow(request.Target);
-            var entity = core.GetStronglyTypedEntity(row.ToEntity(), row.Metadata, request.ColumnSet);
+
+            // Calculate the formula fields before we filter the fetched columns
+            var looseEntity = row.ToEntity();
+            core.ExecuteFormulaFields(row.Metadata, looseEntity).GetAwaiter().GetResult();
+
+            var entity = core.GetStronglyTypedEntity(looseEntity, row.Metadata, request.ColumnSet);
 
             Utility.SetFormattedValues(db, entity, row.Metadata);
 
@@ -49,7 +55,7 @@ namespace DG.Tools.XrmMockup {
             if (request.RelatedEntitiesQuery != null) {
                 core.AddRelatedEntities(entity, request.RelatedEntitiesQuery, userRef);
             }
-            
+
             var resp = new RetrieveResponse();
             resp.Results["Entity"] = entity;
             return resp;

--- a/src/XrmMockupShared/Utility.cs
+++ b/src/XrmMockupShared/Utility.cs
@@ -1299,6 +1299,34 @@ namespace DG.Tools.XrmMockup
                 return json;
             }
         }
+
+        public static string GetFormulaDefinition(AttributeMetadata field, SourceType sourceType)
+        {
+            if (field.SourceType != (int)sourceType)
+            {
+                return null;
+            }
+
+            switch (field)
+            {
+                case BooleanAttributeMetadata booleanField:
+                    return booleanField.FormulaDefinition;
+                case DateTimeAttributeMetadata dateTimeField:
+                    return dateTimeField.FormulaDefinition;
+                case DecimalAttributeMetadata decimalField:
+                    return decimalField.FormulaDefinition;
+                case IntegerAttributeMetadata integerField:
+                    return integerField.FormulaDefinition;
+                case MoneyAttributeMetadata moneyField:
+                    return moneyField.FormulaDefinition;
+                case PicklistAttributeMetadata picklistField:
+                    return picklistField.FormulaDefinition;
+                case StringAttributeMetadata stringField:
+                    return stringField.FormulaDefinition;
+            }
+
+            return null;
+        }
     }
 
     internal class LogicalNames

--- a/src/XrmMockupShared/XrmMockupShared.projitems
+++ b/src/XrmMockupShared/XrmMockupShared.projitems
@@ -15,7 +15,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)MockupServiceAsync2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MockupServiceAsync.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Plugin\CustomApiManager.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FormulaFieldEvaluator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Requests\CommitFileBlocksUploadRequestHandler.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)requests\RetrieveAllEntitiesRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Requests\UpsertMultipleRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Requests\UpdateMultipleRequestHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)requests\InstantiateTemplateRequestHandler.cs" />

--- a/tests/SharedTests/TestRetrieve.cs
+++ b/tests/SharedTests/TestRetrieve.cs
@@ -287,6 +287,22 @@ namespace DG.XrmMockupTest
         }
 
         [Fact]
+        public void TestFormulaFields()
+        {
+            var adminUserId = Guid.Parse("3b961284-cd7a-4fa3-af7e-89802e88dd5c");
+            var animalId = orgAdminService.Create(new dg_animal
+            {
+                dg_name = "Fluffy",
+                OwnerId = new EntityReference(SystemUser.EntityLogicalName, adminUserId)
+            });
+
+            var userName = SystemUser.Retrieve(orgAdminService, adminUserId, x => x.FirstName).FirstName;
+
+            var animal = dg_animal.Retrieve(orgAdminService, animalId, x => x.dg_AnimalOwner);
+            Assert.Equal($"Fluffy is a very good animal, and {userName} loves them very much", animal.dg_AnimalOwner);
+        }
+
+        [Fact]
         public void TestRetrieveUserByFullName()
         {
             var user = new Entity("systemuser");

--- a/tests/SharedTests/TestRetrieveMultiple.cs
+++ b/tests/SharedTests/TestRetrieveMultiple.cs
@@ -1086,5 +1086,24 @@ namespace DG.XrmMockupTest
                 Assert.Equal(sameName.Id, entities[0].Id);
             }
         }
+
+        [Fact]
+        public void TestFormulaFieldEvaluated()
+        {
+            var adminUserId = Guid.Parse("3b961284-cd7a-4fa3-af7e-89802e88dd5c");
+            var animalId = orgAdminService.Create(new dg_animal
+            {
+                dg_name = "Fluffy",
+                OwnerId = new EntityReference(SystemUser.EntityLogicalName, adminUserId)
+            });
+
+            using (var xrm = new Xrm(orgAdminService))
+            {
+                var userName = xrm.SystemUserSet.Where(u => u.SystemUserId == adminUserId).Select(u => u.FirstName).First();
+                var animal = xrm.dg_animalSet.Where(a => a.dg_animalId == animalId).Select(a => new { a.dg_name, a.dg_AnimalOwner }).First();
+
+                Assert.Equal($"Fluffy is a very good animal, and {userName} loves them very much", animal.dg_AnimalOwner);
+            }
+        }
     }
 }

--- a/tests/SharedTests/UnitTestBase.cs
+++ b/tests/SharedTests/UnitTestBase.cs
@@ -64,6 +64,9 @@ namespace DG.XrmMockupTest
             adminUser["businessunitid"] = crm.RootBusinessUnit;
             adminUser["internalemailaddress"] = "test@test.com";
             adminUser["islicensed"] = true;
+            adminUser["firstname"] = "Admin";
+            adminUser["lastname"] = "User";
+            adminUser["fullname"] = "Admin User";
 
             adminUser = crm.CreateUser(orgAdminService, adminUser, SecurityRoles.SystemAdministrator);
             
@@ -133,6 +136,7 @@ namespace DG.XrmMockupTest
             user["internalemailaddress"] = "camstestuser1@official.mod.uk";
             user["businessunitid"] = crm.RootBusinessUnit;
             user["islicensed"] = true;
+            
             testUser1 = crm.CreateUser(orgAdminService, user, new Guid[] { crm.GetSecurityRole("AccessTeamTest").RoleId });
             testUser1Service = crm.CreateOrganizationService(testUser1.Id);
 

--- a/tests/SharedTests/XrmmockupFixture.cs
+++ b/tests/SharedTests/XrmmockupFixture.cs
@@ -1,5 +1,6 @@
 ﻿using DG.Some.Namespace;
 using DG.Tools.XrmMockup;
+using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Client;
 using System;
 

--- a/tests/TestPluginAssembly365/Context/XrmContext.cs
+++ b/tests/TestPluginAssembly365/Context/XrmContext.cs
@@ -79503,6 +79503,17 @@ namespace DG.XrmFramework.BusinessDomain.ServiceContext {
                 return GetAttributeValue<string>("dg_emptycalculatedfield");
             }
         }
+
+        /// <summary>
+        /// <para>Display Name: AnimalOwner</para>
+        /// </summary>
+        [AttributeLogicalName("dg_animalowner")]
+        public string dg_AnimalOwner
+        {
+            get {
+                return GetAttributeValue<string>("dg_animalowner");
+            }
+        }
         
         /// <summary>
         /// <para>The name of the custom entity.</para>

--- a/tests/XrmMockup365Test/TestFormulaFields.cs
+++ b/tests/XrmMockup365Test/TestFormulaFields.cs
@@ -1,0 +1,80 @@
+﻿using DG.Tools.XrmMockup;
+using DG.XrmFramework.BusinessDomain.ServiceContext;
+using DG.XrmMockupTest;
+using Microsoft.Xrm.Sdk;
+using System;
+using Xunit;
+
+namespace XrmMockup365Test
+{
+    public class TestFormulaFields : UnitTestBase, IOrganizationServiceFactory
+    {
+        public TestFormulaFields(XrmMockupFixture fixture) : base(fixture) { }
+
+        [Theory]
+        [InlineData("123", "1 + 1", "2")]
+        [InlineData("123", "name & \" - \" & accountnumber", "Test - 123")]
+        [InlineData("123", "Concatenate(name, \" - \", Text(accountnumber))", "Test - 123")]
+        [InlineData("123", "If(Decimal(accountnumber) > 0, name & \" - \" & accountnumber, \"No Account Number\")", "Test - 123")]
+        [InlineData("0", "If(Decimal(accountnumber) > 0, name & \" - \" & accountnumber, \"No Account Number\")", "No Account Number")]
+        public async System.Threading.Tasks.Task CanEvaluateExpressionOnEntity(string accountNumber, string formula, string expected)
+        {
+            var evaluator = new FormulaFieldEvaluator(this);
+
+            var account = Create(new Account { Name = "Test", AccountNumber = accountNumber });
+            var result = await evaluator.Evaluate(formula, account);
+            Assert.Equal(expected, result.ToString());
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task CanEvaluateExpressionWithRelatedEntity()
+        {
+            var evaluator = new FormulaFieldEvaluator(this);
+
+            var adminUserId = Guid.Parse("3b961284-cd7a-4fa3-af7e-89802e88dd5c");
+            var animal = Create(new dg_animal { dg_name = "Fluffy", OwnerId = new EntityReference(SystemUser.EntityLogicalName, adminUserId) });
+            var animalFood = Create(new dg_animalfood { dg_AnimalId = new EntityReference(dg_animal.EntityLogicalName, animal.Id), dg_name = "Meatballs" });
+
+            var result = await evaluator.Evaluate("\"Test: \" & dg_animalowner", animal);
+            Assert.Equal("Test: Fluffy is a very good animal, and Admin loves them very much", result);
+
+            result = await evaluator.Evaluate("If(dg_AnimalId.dg_name = \"Fluffy\", \"Test: \" & dg_AnimalId.dg_name & \" eats \" & dg_name, \"New telegraph, who dis?\")", animalFood);
+            Assert.Equal("Test: Fluffy eats Meatballs", result);
+        }
+
+        private TEntity Create<TEntity>(TEntity entity) where TEntity : Entity
+        {
+            var id = orgAdminService.Create(entity);
+
+            return orgAdminService.Retrieve(entity.LogicalName, id, new Microsoft.Xrm.Sdk.Query.ColumnSet(true)).ToEntity<TEntity>();
+        }
+
+        public IOrganizationService CreateOrganizationService(Guid? userId)
+        {
+            if (userId == null || userId == Guid.Empty)
+            {
+                return orgAdminService;
+            }
+            else if (userId == testUser1.Id)
+            {
+                return testUser1Service;
+            }
+            else if (userId == testUser2.Id)
+            {
+                return testUser2Service;
+            }
+            else if (userId == testUser3.Id)
+            {
+                return testUser3Service;
+            }
+            else if (userId == testUser4.Id)
+            {
+                return testUser4Service;
+            }
+            else
+            {
+                throw new ArgumentException($"Unknown userId: {userId}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
If a PowerFx field is included in a Retrieve or RetrieveMultiple call it will be evaluated.

Built based on the published packages from Microsoft. These are only published as pre-release currently.

Does not support using a PowerFx field for filtering.