### PR TITLE
Support for creation and update with IEnumerable relation properties

### DIFF
--- a/src/XrmMockupShared/Core.cs
+++ b/src/XrmMockupShared/Core.cs
@@ -302,6 +302,7 @@ namespace DG.Tools.XrmMockup
             {
                 toReturn = GetEntity(entity.LogicalName);
                 toReturn.SetAttributes(entity.Attributes, metadata, colsToKeep);
+                toReturn.RelatedEntities = entity.RelatedEntities;
 
                 toReturn.Id = entity.Id;
                 toReturn.EntityState = entity.EntityState;

--- a/src/XrmMockupShared/Requests/UpdateRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/UpdateRequestHandler.cs
@@ -6,6 +6,7 @@ using Microsoft.Crm.Sdk.Messages;
 using System.ServiceModel;
 using Microsoft.Xrm.Sdk.Metadata;
 using DG.Tools.XrmMockup.Database;
+using System;
 
 namespace DG.Tools.XrmMockup
 {
@@ -216,6 +217,34 @@ namespace DG.Tools.XrmMockup
             }
 
             Utility.Touch(xrmEntity, row.Metadata, core.TimeOffset, userRef);
+
+            if (request.Target.RelatedEntities.Count > 0)
+            {
+                foreach (var relatedEntities in request.Target.RelatedEntities)
+                {
+                    if (Utility.GetRelationshipMetadataDefaultNull(metadata.EntityMetadata,
+                        relatedEntities.Key.SchemaName, Guid.Empty, userRef) == null)
+                    {
+                        throw new FaultException(
+                            $"Relationship with schemaname '{relatedEntities.Key.SchemaName}' does not exist in metadata");
+                    }
+
+                    if (relatedEntities.Value.Entities.Any(e => Guid.Empty == e.Id))
+                    {
+                        // MS Error = System.ServiceModel.FaultException`1[[Microsoft.Xrm.Sdk.OrganizationServiceFault, Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]] : Entity Id must be specified for Operation
+                        throw new FaultException($"Entity Id must be specified for Operation");
+                    }
+
+                    var associateReq = new AssociateRequest
+                    {
+                        Target = request.Target.ToEntityReference(),
+                        Relationship = relatedEntities.Key,
+                        RelatedEntities = new EntityReferenceCollection(relatedEntities.Value.Entities
+                            .Select(e => e.ToEntityReference()).ToList())
+                    };
+                    core.Execute(associateReq, userRef);
+                }
+            }
 
             db.Update(xrmEntity);
 

--- a/src/XrmMockupShared/Requests/UpdateRequestHandler.cs
+++ b/src/XrmMockupShared/Requests/UpdateRequestHandler.cs
@@ -229,7 +229,7 @@ namespace DG.Tools.XrmMockup
                             $"Relationship with schemaname '{relatedEntities.Key.SchemaName}' does not exist in metadata");
                     }
 
-                    if (relatedEntities.Value.Entities.Any(e => Guid.Empty == e.Id))
+                    if (relatedEntities.Value.Entities.Any(e => e.Id == Guid.Empty))
                     {
                         // MS Error = System.ServiceModel.FaultException`1[[Microsoft.Xrm.Sdk.OrganizationServiceFault, Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35]] : Entity Id must be specified for Operation
                         throw new FaultException($"Entity Id must be specified for Operation");

--- a/tests/SharedTests/TestCreate.cs
+++ b/tests/SharedTests/TestCreate.cs
@@ -278,6 +278,16 @@ namespace DG.XrmMockupTest
             var createdAccountId = orgAdminService.Create(account);
             var query = new QueryExpression(Account.EntityLogicalName) { ColumnSet = new ColumnSet(true), Criteria = new FilterExpression() };
             query.Criteria.AddCondition(new ConditionExpression(Account.GetColumnName<Account>(a => a.AccountId), ConditionOperator.Equal, createdAccountId));
+            query.LinkEntities.Add(new LinkEntity
+            {
+                Columns = new ColumnSet(true),
+                EntityAlias = Account.GetColumnName<Account>(a => a.contact_customer_accounts),
+                JoinOperator = JoinOperator.LeftOuter,
+                LinkFromEntityName = Account.EntityLogicalName,
+                LinkToEntityName = Contact.EntityLogicalName,
+                LinkFromAttributeName = Account.GetColumnName<Account>(a => a.AccountId),
+                LinkToAttributeName = Contact.GetColumnName<Contact>(c => c.contact_customer_accounts)
+            });
             var retrievedAccount = orgAdminService.RetrieveMultiple(query).Entities.FirstOrDefault();
 
             // Assert

--- a/tests/SharedTests/TestCreate.cs
+++ b/tests/SharedTests/TestCreate.cs
@@ -263,5 +263,26 @@ namespace DG.XrmMockupTest
             Assert.NotNull(lead.PriorityCode);
             Assert.NotNull(lead.SalesStageCode);
         }
+
+
+        [Fact]
+        public void CreateEntityWithRelatedEntitiesShouldAssociateCorrectly()
+        {
+            // Arrange
+            var testName = nameof(CreateEntityWithRelatedEntitiesShouldAssociateCorrectly);
+            var account = new Account() { Name = testName };
+            var relatedContacts = new[] { new Contact() { LastName = testName, EMailAddress1 = $"{testName}@delegate.delegate" } };
+            account.contact_customer_accounts = relatedContacts;
+
+            // Act (create & retrieve)
+            var createdAccountId = orgAdminService.Create(account);
+            var query = new QueryExpression(Account.EntityLogicalName) { ColumnSet = new ColumnSet(true), Criteria = new FilterExpression() };
+            query.Criteria.AddCondition(new ConditionExpression(Account.GetColumnName<Account>(a => a.AccountId), ConditionOperator.Equal, createdAccountId));
+            var retrievedAccount = orgAdminService.RetrieveMultiple(query).Entities.FirstOrDefault();
+
+            // Assert
+            Assert.NotNull(retrievedAccount);
+            Assert.Contains(retrievedAccount.Attributes, attr => attr.Key.Contains(Account.GetColumnName<Account>(a => a.contact_customer_accounts)));
+        }
     }
 }

--- a/tests/SharedTests/TestUpdate.cs
+++ b/tests/SharedTests/TestUpdate.cs
@@ -1,6 +1,9 @@
 ﻿using DG.XrmFramework.BusinessDomain.ServiceContext;
 using DG.XrmContext;
 using Xunit;
+using Microsoft.Xrm.Sdk.Query;
+using System.Linq;
+using System.ServiceModel;
 
 namespace DG.XrmMockupTest
 {
@@ -15,6 +18,59 @@ namespace DG.XrmMockupTest
             orgAdminUIService.Update(new Lead { Id = id, Subject = string.Empty });
             var lead = orgAdminService.Retrieve<Lead>(id);
             Assert.Null(lead.Subject);
+        }
+
+
+        [Fact]
+        public void UpdatingEntityWithRelatedEntitiesShouldAssociateCorrectly()
+        {
+            // Arrange
+            var testName = nameof(UpdatingEntityWithRelatedEntitiesShouldAssociateCorrectly);
+            var account = new Account() { Name = testName };
+            var contact = new Contact() { LastName = testName, EMailAddress1 = $"{testName}@delegate.delegate" };
+
+            // Act (create & retrieve)
+            // create/arrange
+            var createdAccountId = orgAdminService.Create(account);
+            var createdContactId = orgAdminService.Create(contact); // SDK requires related entity exists before update (works on create)
+            // update & retrieve
+            account.Id = createdAccountId;
+            account.contact_customer_accounts = new[] { new Contact(createdContactId) };
+            orgAdminService.Update(account);
+            var query = new QueryExpression(Account.EntityLogicalName) { ColumnSet = new ColumnSet(true), Criteria = new FilterExpression() };
+            query.Criteria.AddCondition(new ConditionExpression(Account.GetColumnName<Account>(a => a.AccountId), ConditionOperator.Equal, createdAccountId));
+            query.LinkEntities.Add(new LinkEntity
+            {
+                Columns = new ColumnSet(true),
+                EntityAlias = Account.GetColumnName<Account>(a => a.contact_customer_accounts),
+                JoinOperator = JoinOperator.LeftOuter,
+                LinkFromEntityName = Account.EntityLogicalName,
+                LinkToEntityName = Contact.EntityLogicalName,
+                LinkFromAttributeName = Account.GetColumnName<Account>(a => a.AccountId),
+                LinkToAttributeName = Contact.GetColumnName<Contact>(c => c.contact_customer_accounts)
+            });
+            var retrievedAccount = orgAdminService.RetrieveMultiple(query).Entities.FirstOrDefault();
+            var retrievedContact = Contact.Retrieve(orgAdminService, createdContactId);
+
+            // Assert
+            Assert.NotNull(retrievedAccount);
+            Assert.Equal(createdAccountId, retrievedContact.ParentCustomerId.Id);
+            Assert.Contains(retrievedAccount.Attributes, attr => attr.Key.Contains(Account.GetColumnName<Account>(a => a.contact_customer_accounts)));
+        }
+
+        [Fact]
+        public void UpdatingEntityWithRelatedEntitiesNotCreatedThrowsError()
+        {
+            // Arrange
+            var testName = nameof(UpdatingEntityWithRelatedEntitiesShouldAssociateCorrectly);
+            var account = new Account() { Name = testName };
+            var contact = new Contact() { LastName = testName, EMailAddress1 = $"{testName}@delegate.delegate" };
+
+            // Act & Assert
+            var createdAccountId = orgAdminService.Create(account);
+            account.Id = createdAccountId;
+            account.contact_customer_accounts = new[] { contact };
+            Assert.Throws<FaultException>(() => orgAdminService.Update(account));
         }
     }
 }


### PR DESCRIPTION
### Motivation
The Microsoft.Xrm.Sdk supports setting the 1-M and M-M relationships properties directly.

For a create request the SDK even creates the related entities if they do not exists (this was already implemented prior to this PR in XrmMockup, however was not included in the stronglytypedentity creation). Creating related entities this way, even has some performance benefits (if interested read: https://temmyraharjo.wordpress.com/2024/03/03/dataverse-performance-benchmark-create-related-entity-via-chain-of-create-vs-relatedentities-property/)

For update i found the SDK to throw an error instead of creating the entities, hence the difference in Create- and UpdateRequestHandler implementations.

### Changes
✅ Added cloning of RelatedEntities in stronglytypedentity creation
✅ Added association logic similar to that of CreateRequestHandler to the UpdateRequestHandler

All tests green 👍 