### PR TITLE
Add PowerFx field evaluation settings and tests

### DIFF
--- a/src/XrmMockupShared/Core.cs
+++ b/src/XrmMockupShared/Core.cs
@@ -1173,6 +1173,9 @@ namespace DG.Tools.XrmMockup
 
         internal async System.Threading.Tasks.Task ExecuteFormulaFields(EntityMetadata entityMetadata, Entity entity)
         {
+            if (settings.EnablePowerFxFields == false)
+                return;
+
             var attributes = entityMetadata.Attributes.Where(m => m.SourceType == (int)SourceType.FormulaAttribute);
             foreach (var attr in attributes)
             {

--- a/src/XrmMockupShared/Core.cs
+++ b/src/XrmMockupShared/Core.cs
@@ -703,7 +703,7 @@ namespace DG.Tools.XrmMockup
             }
 
             // Trigger Extension
-            if (this.settings.MockUpExtensions.Any())
+            if (this.settings.MockUpExtensions.Count != 0)
             {
                 /*
                  * When moving business units, more than eight layers occur...
@@ -1173,7 +1173,7 @@ namespace DG.Tools.XrmMockup
 
         internal async System.Threading.Tasks.Task ExecuteFormulaFields(EntityMetadata entityMetadata, Entity entity)
         {
-            if (settings.EnablePowerFxFields == false)
+            if (!settings.EnablePowerFxFields)
                 return;
 
             var attributes = entityMetadata.Attributes.Where(m => m.SourceType == (int)SourceType.FormulaAttribute);

--- a/src/XrmMockupShared/XrmMockupSettings.cs
+++ b/src/XrmMockupShared/XrmMockupSettings.cs
@@ -86,6 +86,13 @@ namespace DG.Tools.XrmMockup
         /// If left empty, assemblies are found relative to dll.
         /// </summary>
         public IEnumerable<Assembly> Assemblies { get; set; }
+
+        /// <summary>
+        /// Optional:
+        /// Enable the evaluation of PowerFx fields.
+        /// Default is true.
+        /// </summary>
+        public bool EnablePowerFxFields { get; set; } = true;
     }
 
 

--- a/tests/XrmMockup365Test/TestFormulaFields.cs
+++ b/tests/XrmMockup365Test/TestFormulaFields.cs
@@ -42,6 +42,15 @@ namespace XrmMockup365Test
             Assert.Equal("Test: Fluffy eats Meatballs", result);
         }
 
+        [Fact(Skip = "Function not implemented in Eval yet")]
+        public async System.Threading.Tasks.Task CanEvaluateExpressionWithUtcToday()
+        {
+            var evaluator = new FormulaFieldEvaluator(this);
+
+            var result = await evaluator.Evaluate("UTCToday()", new dg_animal());
+            Assert.NotNull(result);
+        }
+
         private TEntity Create<TEntity>(TEntity entity) where TEntity : Entity
         {
             var id = orgAdminService.Create(entity);


### PR DESCRIPTION
- Updated `ExecuteCalculatedFields` to check `EnablePowerFxFields` setting.
- Introduced `EnablePowerFxFields` property in `XrmMockupSettings` with default value `true`.
- Added `CanEvaluateExpressionWithUtcToday` test in `TestFormulaFields` for `UTCToday()` evaluation.