### PR TITLE
Fix to win-, close- & lose requests for opportunity and quote, where they don't trigger state change events.

### DIFF
--- a/src/XrmMockupShared/Core.cs
+++ b/src/XrmMockupShared/Core.cs
@@ -1061,6 +1061,8 @@ namespace DG.Tools.XrmMockup
             {
                 case "LoseOpportunity": return "Lose";
                 case "WinOpportunity": return "Win";
+                case "CloseQuote": return "Lose";
+                case "WinQuote": return "Win";
                 default: return requestName;
             }
         }
@@ -1173,6 +1175,13 @@ namespace DG.Tools.XrmMockup
                     ? (request as WinOpportunityRequest).OpportunityClose
                     : (request as LoseOpportunityRequest).OpportunityClose;
                 obj = close.GetAttributeValue<EntityReference>("opportunityid");
+            }
+            else if (request is WinQuoteRequest || request is CloseQuoteRequest)
+            {
+                var close = request is WinQuoteRequest
+                    ? (request as WinQuoteRequest).QuoteClose
+                    : (request as CloseQuoteRequest).QuoteClose;
+                obj = close.GetAttributeValue<EntityReference>("quoteid");
             }
             else if (request is CloseIncidentRequest closeIncidentRequest)
             {

--- a/src/XrmMockupShared/Mappings.cs
+++ b/src/XrmMockupShared/Mappings.cs
@@ -53,6 +53,8 @@ namespace DG.Tools.XrmMockup {
             { typeof(UpsertRequest), EventOperation.Upsert },
             { typeof(WinOpportunityRequest), EventOperation.Win },
             { typeof(LoseOpportunityRequest), EventOperation.Lose },
+            { typeof(WinQuoteRequest), EventOperation.Win },
+            { typeof(CloseQuoteRequest), EventOperation.Lose },
             { typeof(CloseIncidentRequest), EventOperation.Close },
             { typeof(CreateMultipleRequest), EventOperation.CreateMultiple },
             { typeof(UpdateMultipleRequest), EventOperation.UpdateMultiple },
@@ -180,6 +182,10 @@ namespace DG.Tools.XrmMockup {
                     return winOpportunityRequest.OpportunityClose.GetAttributeValue<EntityReference>("opportunityid");
                 case LoseOpportunityRequest loseOpportunityRequest:
                     return loseOpportunityRequest.OpportunityClose.GetAttributeValue<EntityReference>("opportunityid");
+                case WinQuoteRequest winQuoteRequest:
+                    return winQuoteRequest.QuoteClose.GetAttributeValue<EntityReference>("quoteid");
+                case CloseQuoteRequest closeQuoteRequest:
+                    return closeQuoteRequest.QuoteClose.GetAttributeValue<EntityReference>("quoteid");
                 case RetrieveMultipleRequest retrieveMultipleRequest:
                     return GetPrimaryEntityReferenceFromQuery(retrieveMultipleRequest.Query);
                 case CloseIncidentRequest closeIncidentRequest:

--- a/src/XrmMockupShared/Utility.cs
+++ b/src/XrmMockupShared/Utility.cs
@@ -141,14 +141,13 @@ namespace DG.Tools.XrmMockup
 
         internal static void CloseOpportunity(Core core, OpportunityState state, OptionSetValue status, Entity opportunityClose, EntityReference userRef)
         {
-            var setStateHandler = core.RequestHandlers.Find(x => x is SetStateRequestHandler);
             var req = new SetStateRequest()
             {
                 EntityMoniker = opportunityClose.GetAttributeValue<EntityReference>("opportunityid"),
                 State = new OptionSetValue((int)state),
                 Status = status
             };
-            setStateHandler.Execute(req, userRef);
+            core.Execute(req, userRef);
 
             var create = new CreateRequest
             {
@@ -159,14 +158,13 @@ namespace DG.Tools.XrmMockup
 
         internal static void CloseQuote(Core core, QuoteState state, OptionSetValue status, Entity quoteClose, EntityReference userRef)
         {
-            var setStateHandler = core.RequestHandlers.Find(x => x is SetStateRequestHandler);
             var req = new SetStateRequest()
             {
                 EntityMoniker = quoteClose.GetAttributeValue<EntityReference>("quoteid"),
                 State = new OptionSetValue((int)state),
                 Status = status
             };
-            setStateHandler.Execute(req, userRef);
+            core.Execute(req, userRef);
 
             var create = new CreateRequest
             {


### PR DESCRIPTION
## Bug
Found an issue where plugin steps for EventOperation Update and SetState didn't trigger when Win-, Close-, Lose- etc. requests were executed.

### Cause
Cause was that it called the setstate handlers directly instead of the core execute function.
Also Quote had missing mappings to entity.