### PR TITLE
Improve type handling in CovertTo, and the In and Not-In operators for query and fetch expressions

### DIFF
--- a/src/XrmMockup365/XmlHandling.cs
+++ b/src/XrmMockup365/XmlHandling.cs
@@ -42,6 +42,7 @@ namespace DG.Tools.XrmMockup {
                     AttributeName = order.Attribute("attribute").Value,
                     OrderType = order.Attribute("descending") == null || order.Attribute("descending").Value == "false" ? OrderType.Ascending : OrderType.Descending
                 };
+                query.Orders.Add(orderExp);
             }
 
             foreach (var linkEntity in entity.Elements("link-entity")) {

--- a/tests/XrmMockup365Test/TestRetrieveMultiple.cs
+++ b/tests/XrmMockup365Test/TestRetrieveMultiple.cs
@@ -1,6 +1,7 @@
 ﻿using DG.Tools.XrmMockup;
 using DG.XrmContext;
 using DG.XrmFramework.BusinessDomain.ServiceContext;
+using Microsoft.Crm.Sdk.Messages;
 using Microsoft.Xrm.Sdk;
 using Microsoft.Xrm.Sdk.Query;
 using System;
@@ -478,6 +479,29 @@ namespace DG.XrmMockupTest
                 Assert.Equal(2, result.Length);
                 Assert.Equal(account1.Id, result[0].AccountId);
                 Assert.Equal(account2.Id, result[1].AccountId);
+            }
+        }
+
+        [Fact]
+        public void TestFetchOrderByOtherAttributes()
+        {
+            using (var context = new Xrm(orgAdminUIService))
+            {
+                var conversionResponse = (FetchXmlToQueryExpressionResponse)orgAdminUIService.Execute(new FetchXmlToQueryExpressionRequest 
+                {
+                    FetchXml = $@"<fetch>
+                        <entity name='account'>
+                            <filter>
+                                <condition attribute='address1_city' operator='eq' value='Virum'/>
+                            </filter>
+                            <order attribute='createdon' descending='true'/>
+                        </entity>
+                    </fetch>"
+                });
+                EntityCollection result = orgAdminUIService.RetrieveMultiple(conversionResponse.Query);
+                Assert.Equal(2, result.Entities.Count);
+                Assert.Equal(account1.Id, result.Entities[1].GetAttributeValue<Guid>("accountid"));
+                Assert.Equal(account2.Id, result.Entities[0].GetAttributeValue<Guid>("accountid"));
             }
         }
 


### PR DESCRIPTION
Refactored the `ConvertTo` method in `Utility.cs` to improve type conversion logic, add null checks, and support additional scenarios like string-to-boolean conversion. Updated the `Matches` method to use the refactored `ConvertTo` for consistent type handling.

Added tests for query and fetch expressions with `Guid` and `statecode` filters.