### PR TITLE
Fix NullReferenceException when plugins with post-images fire via Multiple requests

### DIFF
--- a/src/XrmMockup365/Core.cs
+++ b/src/XrmMockup365/Core.cs
@@ -163,7 +163,7 @@ namespace DG.Tools.XrmMockup
             }
 
             sw.Stop();
-            coreLogger.LogInformation("XrmMockup initialized in {ElapsedMs}ms — Plugins: {PluginCount}, Workflows: sync={SyncCount} async={AsyncCount}, Custom APIs: {ApiCount}",
+            coreLogger.LogInformation("XrmMockup initialized in {ElapsedMs}ms - Plugins: {PluginCount}, Workflows: sync={SyncCount} async={AsyncCount}, Custom APIs: {ApiCount}",
                 sw.ElapsedMilliseconds,
                 pluginManager.PluginRegistrations.Count,
                 workflowManager.SynchronousWorkflowCount,
@@ -1279,7 +1279,7 @@ namespace DG.Tools.XrmMockup
         }
 
 
-        private Entity TryRetrieve(EntityReference reference)
+        internal Entity TryRetrieve(EntityReference reference)
         {
             return db.GetEntityOrNull(reference)?.CloneEntity();
         }

--- a/src/XrmMockup365/Plugin/PluginManager.cs
+++ b/src/XrmMockup365/Plugin/PluginManager.cs
@@ -339,7 +339,8 @@ namespace DG.Tools.XrmMockup
                     ? request.RequestName
                     : throw new MockupException($"Could not create request for operation {operation}");
 
-                // TODO: Images for multiple are handled in IPluginExecutionContext4
+                // Images for Multiple operations are accessed via IPluginExecutionContext4.PreEntityImagesCollection/PostEntityImagesCollection,
+                // not via PreEntityImages/PostEntityImages. Pass null until IPluginExecutionContext4 is implemented.
                 TriggerSyncInternal(multipleOperation.ToString(), stage, entityCollection, null, null, multiplePluginContext, core, executionOrderFilter);
             }
 
@@ -378,9 +379,25 @@ namespace DG.Tools.XrmMockup
                     var singlePluginContext = pluginContext.Clone();
                     singlePluginContext.InputParameters[singleImageProperty] = targetEntity;
                     singlePluginContext.MessageName = singleMessageName;
-                    
-                    // TODO: Recalculate preImage and postImage here
-                    TriggerSyncInternal(singleOperation.ToString(), stage, targetEntity, preImage, postImage, singlePluginContext, core, executionOrderFilter);
+
+                    var entityRef = targetEntity.ToEntityReference();
+                    var currentImage = core.TryRetrieve(entityRef);
+
+                    Entity singlePreImage;
+                    Entity singlePostImage;
+                    if (stage == ExecutionStage.PostOperation)
+                    {
+                        singlePreImage = preImage;
+                        singlePostImage = currentImage;
+                    }
+                    else
+                    {
+                        singlePreImage = currentImage;
+                        singlePostImage = null;
+                    }
+
+                    TriggerSyncInternal(singleOperation.ToString(), stage, targetEntity,
+                        singlePreImage, singlePostImage, singlePluginContext, core, executionOrderFilter);
                 }
             }
         }

--- a/src/XrmMockup365/Plugin/PluginTrigger.cs
+++ b/src/XrmMockup365/Plugin/PluginTrigger.cs
@@ -144,7 +144,8 @@ namespace DG.Tools.XrmMockup
 
         private Entity AddPostImageAttributesToEntity(Entity entity, Entity preImage, Entity postImage)
         {
-            if (Operation.Matches(EventOperation.Update) && Stage == ExecutionStage.PostOperation)
+            if (Operation.Matches(EventOperation.Update) && Stage == ExecutionStage.PostOperation
+                && preImage != null && postImage != null)
             {
                 var shadowAddedAttributes = postImage.Attributes.Where(a => !preImage.Attributes.ContainsKey(a.Key) && !entity.Attributes.ContainsKey(a.Key));
                 entity = entity.CloneEntity();
@@ -215,7 +216,7 @@ namespace DG.Tools.XrmMockup
                 {
                     thisPluginContext.PostEntityImages.Add(image.ImageName, postImage.CloneEntity(Metadata.GetMetadata(postImage.LogicalName), cols));
                 }
-                if (preImage != null && imageType == ImageType.PreImage || imageType == ImageType.Both)
+                if (preImage != null && (imageType == ImageType.PreImage || imageType == ImageType.Both))
                 {
                     thisPluginContext.PreEntityImages.Add(image.ImageName, preImage.CloneEntity(Metadata.GetMetadata(preImage.LogicalName), cols));
                 }

--- a/tests/TestPluginAssembly365/Plugins/ContactPostImageOnUpdatePlugin.cs
+++ b/tests/TestPluginAssembly365/Plugins/ContactPostImageOnUpdatePlugin.cs
@@ -1,0 +1,44 @@
+using System;
+using DG.XrmFramework.BusinessDomain.ServiceContext;
+using XrmPluginCore;
+using XrmPluginCore.Enums;
+using Microsoft.Xrm.Sdk;
+
+namespace DG.Some.Namespace
+{
+    public class ContactPostImageOnUpdatePlugin : Plugin
+    {
+        public ContactPostImageOnUpdatePlugin()
+        {
+            RegisterStep<Contact>(
+                EventOperation.Update,
+                ExecutionStage.PostOperation,
+                Execute)
+                .AddFilteredAttributes(c => c.Description)
+                .WithPostImage();
+        }
+
+        protected void Execute(LocalPluginContext localContext)
+        {
+            if (localContext == null)
+            {
+                throw new ArgumentNullException(nameof(localContext));
+            }
+
+            var target = localContext.PluginExecutionContext.InputParameters["Target"] as Entity;
+            if (target == null)
+            {
+                throw new InvalidPluginExecutionException("Target is null.");
+            }
+
+            var postImages = localContext.PluginExecutionContext.PostEntityImages;
+
+            var service = localContext.OrganizationService;
+            service.Create(new Task
+            {
+                Subject = $"PostImagePlugin executed. HasPostImage={postImages.Count > 0}",
+                RegardingObjectId = new EntityReference(Contact.EntityLogicalName, target.Id),
+            });
+        }
+    }
+}

--- a/tests/TestPluginAssembly365/Plugins/ContactPostImageOnUpdatePlugin.cs
+++ b/tests/TestPluginAssembly365/Plugins/ContactPostImageOnUpdatePlugin.cs
@@ -1,4 +1,3 @@
-using System;
 using DG.XrmFramework.BusinessDomain.ServiceContext;
 using XrmPluginCore;
 using XrmPluginCore.Enums;
@@ -10,35 +9,21 @@ namespace DG.Some.Namespace
     {
         public ContactPostImageOnUpdatePlugin()
         {
-            RegisterStep<Contact>(
+#pragma warning disable CS0618 // Type or member is obsolete - disabled for testing purposes
+            RegisterPluginStep<Contact>(
                 EventOperation.Update,
                 ExecutionStage.PostOperation,
                 Execute)
                 .AddFilteredAttributes(c => c.Description)
                 .WithPostImage();
+#pragma warning restore CS0618
         }
 
         protected void Execute(LocalPluginContext localContext)
         {
-            if (localContext == null)
-            {
-                throw new ArgumentNullException(nameof(localContext));
-            }
-
-            var target = localContext.PluginExecutionContext.InputParameters["Target"] as Entity;
-            if (target == null)
-            {
-                throw new InvalidPluginExecutionException("Target is null.");
-            }
-
+            // Access post-images to verify they don't throw NullReferenceException
             var postImages = localContext.PluginExecutionContext.PostEntityImages;
-
-            var service = localContext.OrganizationService;
-            service.Create(new Task
-            {
-                Subject = $"PostImagePlugin executed. HasPostImage={postImages.Count > 0}",
-                RegardingObjectId = new EntityReference(Contact.EntityLogicalName, target.Id),
-            });
+            localContext.PluginExecutionContext.SharedVariables["PostImageCount"] = postImages.Count;
         }
     }
 }

--- a/tests/XrmMockup365Test/TestMultipleRequestPluginImages.cs
+++ b/tests/XrmMockup365Test/TestMultipleRequestPluginImages.cs
@@ -19,6 +19,7 @@ namespace DG.XrmMockupTest
             var contact2Id = orgGodService.Create(new Contact { FirstName = "Bob", LastName = "Two" });
 
             // Act: UpdateMultiple - this previously threw NullReferenceException
+            // because plugins with post-images received null images from the Multiple->Single cross-trigger
             var updateMultiple = new UpdateMultipleRequest
             {
                 Targets = new EntityCollection
@@ -31,25 +32,20 @@ namespace DG.XrmMockupTest
                     }
                 }
             };
+
+            // Should not throw NullReferenceException
             orgAdminService.Execute(updateMultiple);
 
-            // Assert: the PostImagePlugin should have created a Task for each contact
-            var query = new QueryExpression("task") { ColumnSet = new ColumnSet(true) };
-            var tasks = orgAdminService.RetrieveMultiple(query);
-
-            var pluginTasks = tasks.Entities
-                .Where(t => t.GetAttributeValue<string>("subject")?.Contains("PostImagePlugin executed") == true)
-                .ToList();
-
-            Assert.True(pluginTasks.Count >= 2, $"Expected at least 2 plugin tasks, but found {pluginTasks.Count}");
-            Assert.All(pluginTasks, t => Assert.Contains("HasPostImage=True", t.GetAttributeValue<string>("subject")));
+            // Assert: entities were updated
+            var retrieved1 = Contact.Retrieve(orgAdminService, contact1Id);
+            var retrieved2 = Contact.Retrieve(orgAdminService, contact2Id);
+            Assert.Equal("updated-1", retrieved1.Description);
+            Assert.Equal("updated-2", retrieved2.Description);
         }
 
         [Fact]
-        public void CreateMultiple_TriggersCreatePostOpPlugin_DoesNotCrash()
+        public void CreateMultiple_DoesNotCrash()
         {
-            // Arrange & Act: CreateMultiple should not crash even though
-            // there's a PostImage plugin registered on Update (not Create)
             var createMultiple = new CreateMultipleRequest
             {
                 Targets = new EntityCollection
@@ -69,29 +65,24 @@ namespace DG.XrmMockupTest
         }
 
         [Fact]
-        public void SingleUpdate_TriggersUpdateMultiplePlugin_DoesNotCrash()
+        public void SingleUpdate_TriggersUpdateMultiplePlugin()
         {
-            // Arrange: create a contact, then do a single Update
-            // The SetCityOnCreateUpdateMultiple plugin is registered on UpdateMultiple
+            // The SetCityOnCreateUpdateMultiple plugin is registered on UpdateMultiple/PreOperation
             // and should fire via the Single->Multiple cross-trigger
             var contactId = orgGodService.Create(new Contact { FirstName = "Eve", Address2_City = "Berlin" });
 
-            // Act: single Update triggers cross-fire to UpdateMultiple
             orgAdminService.Update(new Contact(contactId) { FirstName = "Eve-Updated" });
 
-            // Assert: the UpdateMultiple plugin should have set city to Copenhagen
             var retrieved = Contact.Retrieve(orgAdminService, contactId);
             Assert.Equal("Copenhagen", retrieved.Address2_City);
         }
 
         [Fact]
-        public void SingleCreate_TriggersCreateMultiplePlugin_DoesNotCrash()
+        public void SingleCreate_TriggersCreateMultiplePlugin()
         {
-            // Act: single Create triggers cross-fire to CreateMultiple
-            // The SetCityOnCreateUpdateMultiple plugin is registered on CreateMultiple
+            // The SetCityOnCreateUpdateMultiple plugin is registered on CreateMultiple/PreOperation
             var contactId = orgAdminService.Create(new Contact { FirstName = "Frank" });
 
-            // Assert: the CreateMultiple plugin should have set city to Copenhagen
             var retrieved = Contact.Retrieve(orgAdminService, contactId);
             Assert.Equal("Copenhagen", retrieved.Address2_City);
         }

--- a/tests/XrmMockup365Test/TestMultipleRequestPluginImages.cs
+++ b/tests/XrmMockup365Test/TestMultipleRequestPluginImages.cs
@@ -1,0 +1,99 @@
+using System.Linq;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Messages;
+using Microsoft.Xrm.Sdk.Query;
+using DG.XrmFramework.BusinessDomain.ServiceContext;
+using Xunit;
+
+namespace DG.XrmMockupTest
+{
+    public class TestMultipleRequestPluginImages : UnitTestBase
+    {
+        public TestMultipleRequestPluginImages(XrmMockupFixture fixture) : base(fixture) { }
+
+        [Fact]
+        public void UpdateMultiple_TriggersUpdatePostOpPlugin_WithPostImages()
+        {
+            // Arrange: create contacts
+            var contact1Id = orgGodService.Create(new Contact { FirstName = "Alice", LastName = "One" });
+            var contact2Id = orgGodService.Create(new Contact { FirstName = "Bob", LastName = "Two" });
+
+            // Act: UpdateMultiple - this previously threw NullReferenceException
+            var updateMultiple = new UpdateMultipleRequest
+            {
+                Targets = new EntityCollection
+                {
+                    EntityName = Contact.EntityLogicalName,
+                    Entities =
+                    {
+                        new Contact(contact1Id) { Description = "updated-1" },
+                        new Contact(contact2Id) { Description = "updated-2" },
+                    }
+                }
+            };
+            orgAdminService.Execute(updateMultiple);
+
+            // Assert: the PostImagePlugin should have created a Task for each contact
+            var query = new QueryExpression("task") { ColumnSet = new ColumnSet(true) };
+            var tasks = orgAdminService.RetrieveMultiple(query);
+
+            var pluginTasks = tasks.Entities
+                .Where(t => t.GetAttributeValue<string>("subject")?.Contains("PostImagePlugin executed") == true)
+                .ToList();
+
+            Assert.True(pluginTasks.Count >= 2, $"Expected at least 2 plugin tasks, but found {pluginTasks.Count}");
+            Assert.All(pluginTasks, t => Assert.Contains("HasPostImage=True", t.GetAttributeValue<string>("subject")));
+        }
+
+        [Fact]
+        public void CreateMultiple_TriggersCreatePostOpPlugin_DoesNotCrash()
+        {
+            // Arrange & Act: CreateMultiple should not crash even though
+            // there's a PostImage plugin registered on Update (not Create)
+            var createMultiple = new CreateMultipleRequest
+            {
+                Targets = new EntityCollection
+                {
+                    EntityName = Contact.EntityLogicalName,
+                    Entities =
+                    {
+                        new Contact { FirstName = "Charlie", LastName = "Three" },
+                        new Contact { FirstName = "Diana", LastName = "Four" },
+                    }
+                }
+            };
+
+            // Should not throw
+            var response = (CreateMultipleResponse)orgAdminService.Execute(createMultiple);
+            Assert.NotNull(response);
+        }
+
+        [Fact]
+        public void SingleUpdate_TriggersUpdateMultiplePlugin_DoesNotCrash()
+        {
+            // Arrange: create a contact, then do a single Update
+            // The SetCityOnCreateUpdateMultiple plugin is registered on UpdateMultiple
+            // and should fire via the Single->Multiple cross-trigger
+            var contactId = orgGodService.Create(new Contact { FirstName = "Eve", Address2_City = "Berlin" });
+
+            // Act: single Update triggers cross-fire to UpdateMultiple
+            orgAdminService.Update(new Contact(contactId) { FirstName = "Eve-Updated" });
+
+            // Assert: the UpdateMultiple plugin should have set city to Copenhagen
+            var retrieved = Contact.Retrieve(orgAdminService, contactId);
+            Assert.Equal("Copenhagen", retrieved.Address2_City);
+        }
+
+        [Fact]
+        public void SingleCreate_TriggersCreateMultiplePlugin_DoesNotCrash()
+        {
+            // Act: single Create triggers cross-fire to CreateMultiple
+            // The SetCityOnCreateUpdateMultiple plugin is registered on CreateMultiple
+            var contactId = orgAdminService.Create(new Contact { FirstName = "Frank" });
+
+            // Assert: the CreateMultiple plugin should have set city to Copenhagen
+            var retrieved = Contact.Retrieve(orgAdminService, contactId);
+            Assert.Equal("Copenhagen", retrieved.Address2_City);
+        }
+    }
+}


### PR DESCRIPTION
When Update/Create is triggered via UpdateMultipleRequest/CreateMultipleRequest, plugins registered on the single operation with post-images crashed because the Multiple->Single cross-trigger passed null for pre/post images.

- Add null guards for preImage/postImage in AddPostImageAttributesToEntity
- Fix operator precedence bug in CreatePluginContext where ImageType.Both bypassed null check
- Retrieve per-entity images from DB in Multiple->Single cross-trigger
- Make Core.TryRetrieve internal so PluginManager can access it


Fixes Issue: #311