### PR TITLE
Fix error when deleting target record in post-operation plugin

### DIFF
--- a/src/XrmMockup365/Core.cs
+++ b/src/XrmMockup365/Core.cs
@@ -975,13 +975,13 @@ namespace DG.Tools.XrmMockup
                     var entityLogicalName = ((Entity)request.Parameters["Target"]).LogicalName;
                     var reference = primaryRef ?? new EntityReference(entityLogicalName, createResponse.id);
 
-                    var createdEntity = GetDbRow(reference).ToEntity();
+                    var createdEntity = TryRetrieve(reference);
                     TriggerExtension(
                         new MockupService(this, userRef.Id, pluginContext), request,
                         createdEntity, null, userRef);
                     break;
                 case "Update":
-                    var updatedEntity = GetDbRow(primaryRef).ToEntity();
+                    var updatedEntity = TryRetrieve(primaryRef);
                     TriggerExtension(
                         new MockupService(this, userRef.Id, pluginContext), request,
                         updatedEntity, preImage, userRef);

--- a/tests/TestPluginAssembly365/Plugins/AccountDeleteInPostPlugin.cs
+++ b/tests/TestPluginAssembly365/Plugins/AccountDeleteInPostPlugin.cs
@@ -2,6 +2,7 @@
 namespace DG.Some.Namespace {
     using System;
     using DG.XrmFramework.BusinessDomain.ServiceContext;
+    using TestPluginAssembly365.Plugins.SyncAsyncTest;
     using XrmPluginCore;
     using XrmPluginCore.Enums;
 
@@ -9,13 +10,15 @@ namespace DG.Some.Namespace {
     /// Test plugin that deletes the target account in a post-Update operation.
     /// Used to verify that XrmMockup handles record deletion inside a post-operation plugin gracefully.
     /// </summary>
-    public class AccountDeleteInPostPlugin : Plugin {
+    public class AccountDeleteInPostPlugin : TestPlugin {
 
         public AccountDeleteInPostPlugin() {
+#pragma warning disable CS0618 // Type or member is obsolete - disabled for testing purposes
             RegisterPluginStep<Account>(
                 EventOperation.Update,
                 ExecutionStage.PostOperation,
                 Execute);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         protected void Execute(LocalPluginContext localContext) {

--- a/tests/TestPluginAssembly365/Plugins/AccountDeleteInPostPlugin.cs
+++ b/tests/TestPluginAssembly365/Plugins/AccountDeleteInPostPlugin.cs
@@ -11,7 +11,6 @@ namespace DG.Some.Namespace {
     /// Used to verify that XrmMockup handles record deletion inside a post-operation plugin gracefully.
     /// </summary>
     public class AccountDeleteInPostPlugin : TestPlugin {
-
         public AccountDeleteInPostPlugin() {
 #pragma warning disable CS0618 // Type or member is obsolete - disabled for testing purposes
             RegisterPluginStep<Account>(

--- a/tests/TestPluginAssembly365/Plugins/AccountDeleteInPostPlugin.cs
+++ b/tests/TestPluginAssembly365/Plugins/AccountDeleteInPostPlugin.cs
@@ -1,0 +1,30 @@
+
+namespace DG.Some.Namespace {
+    using System;
+    using DG.XrmFramework.BusinessDomain.ServiceContext;
+    using XrmPluginCore;
+    using XrmPluginCore.Enums;
+
+    /// <summary>
+    /// Test plugin that deletes the target account in a post-Update operation.
+    /// Used to verify that XrmMockup handles record deletion inside a post-operation plugin gracefully.
+    /// </summary>
+    public class AccountDeleteInPostPlugin : Plugin {
+
+        public AccountDeleteInPostPlugin() {
+            RegisterPluginStep<Account>(
+                EventOperation.Update,
+                ExecutionStage.PostOperation,
+                Execute);
+        }
+
+        protected void Execute(LocalPluginContext localContext) {
+            if (localContext == null) {
+                throw new ArgumentNullException("localContext");
+            }
+
+            var service = localContext.OrganizationService;
+            service.Delete(Account.EntityLogicalName, localContext.PluginExecutionContext.PrimaryEntityId);
+        }
+    }
+}

--- a/tests/XrmMockup365Test/TestPlugins.cs
+++ b/tests/XrmMockup365Test/TestPlugins.cs
@@ -236,13 +236,13 @@ namespace DG.XrmMockupTest
 
             // Verify the account was actually deleted by the plugin
             var retrieved = orgAdminService.RetrieveMultiple(
-                new Microsoft.Xrm.Sdk.Query.QueryExpression(Account.EntityLogicalName)
+                new QueryExpression(Account.EntityLogicalName)
                 {
-                    Criteria = new Microsoft.Xrm.Sdk.Query.FilterExpression
+                    Criteria = new FilterExpression
                     {
                         Conditions =
                         {
-                            new Microsoft.Xrm.Sdk.Query.ConditionExpression("accountid", Microsoft.Xrm.Sdk.Query.ConditionOperator.Equal, account.Id)
+                            new ConditionExpression("accountid", ConditionOperator.Equal, account.Id)
                         }
                     }
                 });

--- a/tests/XrmMockup365Test/TestPlugins.cs
+++ b/tests/XrmMockup365Test/TestPlugins.cs
@@ -221,10 +221,6 @@ namespace DG.XrmMockupTest
             }
         }
 
-        /// <summary>
-        /// Verifies that a post-Update plugin can delete the target record without causing an error.
-        /// Regression test for: https://github.com/delegateas/XrmMockup/issues/303
-        /// </summary>
         [Fact]
         public void TestDeleteTargetInPostUpdatePlugin()
         {

--- a/tests/XrmMockup365Test/TestPlugins.cs
+++ b/tests/XrmMockup365Test/TestPlugins.cs
@@ -220,5 +220,37 @@ namespace DG.XrmMockupTest
                 );
             }
         }
+
+        /// <summary>
+        /// Verifies that a post-Update plugin can delete the target record without causing an error.
+        /// Regression test for: https://github.com/delegateas/XrmMockup/issues/303
+        /// </summary>
+        [Fact]
+        public void TestDeleteTargetInPostUpdatePlugin()
+        {
+            crm.DisableRegisteredPlugins(true);
+            crm.RegisterAdditionalPlugins(DG.Tools.XrmMockup.PluginRegistrationScope.Temporary, typeof(DG.Some.Namespace.AccountDeleteInPostPlugin));
+
+            var account = new Account { Name = "DeleteMe" };
+            account.Id = orgAdminService.Create(account);
+
+            // Update triggers AccountDeleteInPostPlugin which deletes the account — should not throw
+            var update = new Account { Id = account.Id, Name = "Updated" };
+            orgAdminService.Update(update);
+
+            // Verify the account was actually deleted by the plugin
+            var retrieved = orgAdminService.RetrieveMultiple(
+                new Microsoft.Xrm.Sdk.Query.QueryExpression(Account.EntityLogicalName)
+                {
+                    Criteria = new Microsoft.Xrm.Sdk.Query.FilterExpression
+                    {
+                        Conditions =
+                        {
+                            new Microsoft.Xrm.Sdk.Query.ConditionExpression("accountid", Microsoft.Xrm.Sdk.Query.ConditionOperator.Equal, account.Id)
+                        }
+                    }
+                });
+            Assert.Empty(retrieved.Entities);
+        }
     }
 }


### PR DESCRIPTION
## Problem

When a plugin registered on `Update` (post-sync or post-async) deletes the target record, XrmMockup throws an error:

```
The record of type 'email' with id '...' does not exist.
```

**Root cause:** After post-operation plugins run, `Core.cs` calls `GetDbRow(primaryRef).ToEntity()` in the TriggerExtension switch for both "Create" and "Update" cases. `GetDbRow` throws a `FaultException` if the record no longer exists — which happens when a post-operation plugin deleted it.

## Fix

Replace `GetDbRow(...).ToEntity()` with `TryRetrieve(...)` in the TriggerExtension switch block for both "Create" and "Update" cases. `TryRetrieve` uses `GetEntityOrNull` which returns `null` instead of throwing, and `TriggerExtension` handles `null` gracefully.

## Changes

- **`src/XrmMockup365/Core.cs`**: Replace `GetDbRow(...).ToEntity()` with `TryRetrieve(...)` for Create and Update in TriggerExtension switch
- **`tests/TestPluginAssembly365/Plugins/AccountDeleteInPostPlugin.cs`** (new): Test plugin that deletes the target account in a post-Update operation
- **`tests/XrmMockup365Test/TestPlugins.cs`**: New regression test `TestDeleteTargetInPostUpdatePlugin`

Fixes #303