### PR TITLE
Fix calculated-field Concat cast and skip unused calc/formula fields

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,7 @@
+### 1.18.3 - 26 June 2026
+* Fix: Classic calculated-field Concat threw `InvalidCastException` when a non-string column was concatenated with a string column, blocking Retrieve/RetrieveMultiple even if the calculated column was not requested
+* Improvement: Retrieve and RetrieveMultiple now skip evaluating calculated and formula fields that are not referenced by the ColumnSet (or, for calc fields, by the criteria/orders/links)
+
 ### 1.18.2 - 25 June 2026
 * Fix: Top level link criteria were unioned instead of cross joined
 

--- a/src/XrmMockup365/Core.cs
+++ b/src/XrmMockup365/Core.cs
@@ -1133,10 +1133,20 @@ namespace DG.Tools.XrmMockup
             return entityMetadata;
         }
 
-        internal void ExecuteCalculatedFields(EntityMetadata entityMetadata, Entity entity)
+        internal void ExecuteCalculatedFields(EntityMetadata entityMetadata, Entity entity, ISet<string> requestedAttributes = null)
         {
+            // requestedAttributes == null means "all columns" (e.g. ColumnSet(true)); only filter when
+            // the caller has supplied an explicit list. Skipping unrequested calculated columns avoids
+            // running their formulas, which is both faster and prevents a broken/unused calculated
+            // field from blocking unrelated reads (the original cast bug was surfaced this way: a
+            // mixed-type Concat in one calc field blew up every Retrieve, even when the column was
+            // never selected).
             var attributes = entityMetadata.Attributes.Where(
                 m => m.SourceType == (int)SourceType.CalculatedAttribute && !(m is MoneyAttributeMetadata && m.LogicalName.EndsWith("_base")));
+            if (requestedAttributes != null)
+            {
+                attributes = attributes.Where(m => requestedAttributes.Contains(m.LogicalName));
+            }
 
             foreach (var attr in attributes)
             {
@@ -1166,12 +1176,16 @@ namespace DG.Tools.XrmMockup
             }
         }
 
-        internal async System.Threading.Tasks.Task ExecuteFormulaFields(EntityMetadata entityMetadata, Entity entity)
+        internal async System.Threading.Tasks.Task ExecuteFormulaFields(EntityMetadata entityMetadata, Entity entity, ISet<string> requestedAttributes = null)
         {
             if (!settings.EnablePowerFxFields)
                 return;
 
             var attributes = entityMetadata.Attributes.Where(m => m.SourceType == (int)SourceType.FormulaAttribute);
+            if (requestedAttributes != null)
+            {
+                attributes = attributes.Where(m => requestedAttributes.Contains(m.LogicalName));
+            }
             foreach (var attr in attributes)
             {
                 var definition = Utility.GetFormulaDefinition(attr, SourceType.FormulaAttribute);

--- a/src/XrmMockup365/Requests/RetrieveMultipleRequestHandler.cs
+++ b/src/XrmMockup365/Requests/RetrieveMultipleRequestHandler.cs
@@ -46,6 +46,15 @@ namespace DG.Tools.XrmMockup
 
             var entityMetadata = metadata.EntityMetadata[queryExpr.EntityName];
 
+            // Calculated fields must be projected onto each row before criteria matching, so the set
+            // of "needed" calc columns is the union of the ColumnSet and any column referenced by the
+            // filter/order. Formula fields are only used after filtering, so they only need to honour
+            // the ColumnSet. A null set means "all columns" (e.g. ColumnSet(true) or an unbounded
+            // query); when populated, unrequested computed columns are skipped to avoid paying their
+            // workflow cost and to stop a broken calc field on one column from blocking every read.
+            var calculatedNeeded = GetNeededAttributesForCalculatedFields(queryExpr);
+            var formulaNeeded = GetRequestedAttributes(queryExpr.ColumnSet);
+
             var collection = new ConcurrentBag<KeyValuePair<DbRow, Entity>>();
 
             Parallel.ForEach(rows, row =>
@@ -54,7 +63,7 @@ namespace DG.Tools.XrmMockup
 
                 // Calculated fields are evaluated on demand (never persisted); project them onto the
                 // in-memory entity before criteria matching so filters can reference them.
-                core.ExecuteCalculatedFields(row.Metadata, entity);
+                core.ExecuteCalculatedFields(row.Metadata, entity, calculatedNeeded);
 
                 var toAdd = core.GetStronglyTypedEntity(entity, row.Metadata, null);
 
@@ -122,7 +131,7 @@ namespace DG.Tools.XrmMockup
             var orderedEntities = tempSortedList.Select(x => x.Value).ToArray();
 
             // Calculate formula fields before we filter the fetched columns
-            Parallel.ForEach(orderedEntities, entity => core.ExecuteFormulaFields(entityMetadata, entity).GetAwaiter().GetResult());
+            Parallel.ForEach(orderedEntities, entity => core.ExecuteFormulaFields(entityMetadata, entity, formulaNeeded).GetAwaiter().GetResult());
 
             // Refine and filter the columns
             var entitiesToReturn = RefineEntityAttributes(orderedEntities, queryExpr.ColumnSet);
@@ -327,6 +336,47 @@ namespace DG.Tools.XrmMockup
                 return;
             }
             condition.EntityName = alias;
+        }
+
+        // Returns null when every column on the primary entity is in play (AllColumns / no
+        // ColumnSet), otherwise the set of attribute names referenced anywhere a calc column could
+        // be observed: ColumnSet, criteria, orders, and the link-from sides of inner links (where a
+        // null on a calc column would silently change join semantics). When non-null, the Core can
+        // skip evaluating any other calculated column for the row.
+        private static ISet<string> GetNeededAttributesForCalculatedFields(QueryExpression query)
+        {
+            if (query.ColumnSet == null || query.ColumnSet.AllColumns) return null;
+
+            var set = new HashSet<string>(query.ColumnSet.Columns, StringComparer.OrdinalIgnoreCase);
+            CollectFilterAttributes(query.Criteria, set);
+            foreach (var order in query.Orders)
+            {
+                if (!string.IsNullOrEmpty(order.AttributeName)) set.Add(order.AttributeName);
+            }
+            foreach (var link in query.LinkEntities)
+            {
+                if (!string.IsNullOrEmpty(link.LinkFromAttributeName)) set.Add(link.LinkFromAttributeName);
+            }
+            return set;
+        }
+
+        private static ISet<string> GetRequestedAttributes(ColumnSet columnSet)
+        {
+            if (columnSet == null || columnSet.AllColumns) return null;
+            return new HashSet<string>(columnSet.Columns, StringComparer.OrdinalIgnoreCase);
+        }
+
+        private static void CollectFilterAttributes(FilterExpression filter, HashSet<string> set)
+        {
+            if (filter == null) return;
+            foreach (var cond in filter.Conditions)
+            {
+                if (!string.IsNullOrEmpty(cond.AttributeName)) set.Add(cond.AttributeName);
+            }
+            foreach (var sub in filter.Filters)
+            {
+                CollectFilterAttributes(sub, set);
+            }
         }
     }
 }

--- a/src/XrmMockup365/Requests/RetrieveRequestHandler.cs
+++ b/src/XrmMockup365/Requests/RetrieveRequestHandler.cs
@@ -38,10 +38,14 @@ namespace DG.Tools.XrmMockup {
             }
 
             // Calculate the (on-demand, never-persisted) calculated and formula fields onto the
-            // entity we are about to return, before we filter the fetched columns.
+            // entity we are about to return, before we filter the fetched columns. Only compute the
+            // columns the caller actually asked for: an unselected calculated/formula column has no
+            // observable effect on the response, and skipping it avoids paying the per-row workflow
+            // cost (and prevents a broken calc field on an unrelated column from breaking this read).
             var looseEntity = row.ToEntity();
-            core.ExecuteCalculatedFields(row.Metadata, looseEntity);
-            core.ExecuteFormulaFields(row.Metadata, looseEntity).GetAwaiter().GetResult();
+            var requested = GetRequestedComputedAttributes(request.ColumnSet);
+            core.ExecuteCalculatedFields(row.Metadata, looseEntity, requested);
+            core.ExecuteFormulaFields(row.Metadata, looseEntity, requested).GetAwaiter().GetResult();
 
             var entity = core.GetStronglyTypedEntity(looseEntity, row.Metadata, request.ColumnSet);
 
@@ -59,6 +63,15 @@ namespace DG.Tools.XrmMockup {
             var resp = new RetrieveResponse();
             resp.Results["Entity"] = entity;
             return resp;
+        }
+
+        // Returns null when the caller asked for AllColumns (treat as "everything"); otherwise the
+        // explicit column names. Calculated/formula attributes whose LogicalName is not in this set
+        // can be skipped entirely.
+        private static ISet<string> GetRequestedComputedAttributes(ColumnSet columnSet)
+        {
+            if (columnSet == null || columnSet.AllColumns) return null;
+            return new HashSet<string>(columnSet.Columns, StringComparer.OrdinalIgnoreCase);
         }
     }
 }

--- a/src/XrmMockup365/Workflow/WorkflowNode/Concat.cs
+++ b/src/XrmMockup365/Workflow/WorkflowNode/Concat.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Xrm.Sdk;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Runtime.Serialization;
 
@@ -24,8 +25,34 @@ namespace WorkflowExecuter
             IOrganizationService orgService, IOrganizationServiceFactory factory, ITracingService trace)
         {
             var variablesInstance = variables;
-            var strings = Parameters[0].Select(p => (string)variablesInstance[p]).ToArray();
+            // Dataverse permits a calculated field's Concat to receive non-string operands (numbers,
+            // money, dates, etc.) and stringifies them with invariant culture before joining. Mirror
+            // that — the previous (string) cast threw InvalidCastException on any non-string value,
+            // which propagated out of Retrieve/RetrieveMultiple even when the calculated column was
+            // not requested.
+            var strings = Parameters[0].Select(p => Stringify(variablesInstance[p])).ToArray();
             variables[VariableName] = string.Concat(strings);
+        }
+
+        private static string Stringify(object value)
+        {
+            switch (value)
+            {
+                case null:
+                    return string.Empty;
+                case string s:
+                    return s;
+                case Money money:
+                    return money.Value.ToString(CultureInfo.InvariantCulture);
+                case EntityReference er:
+                    return er.Name ?? string.Empty;
+                case OptionSetValue osv:
+                    return osv.Value.ToString(CultureInfo.InvariantCulture);
+                case IFormattable f:
+                    return f.ToString(null, CultureInfo.InvariantCulture);
+                default:
+                    return value.ToString();
+            }
         }
     }
 }

--- a/tests/XrmMockup365Test/TestCalculatedFields.cs
+++ b/tests/XrmMockup365Test/TestCalculatedFields.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Collections.Generic;
+using WorkflowExecuter;
+using Xunit;
+
+namespace DG.XrmMockupTest
+{
+    // The classic calculated-field engine concatenates strings via the WorkflowExecuter.Concat node.
+    // Dataverse permits a calculated field that references a non-string column inside Concat (the
+    // platform stringifies the value before joining), so the node must accept any operand type, not
+    // only strings. Before the fix, the (string) cast threw InvalidCastException, which the Retrieve
+    // / RetrieveMultiple handlers re-raised because they execute every calculated field on each row
+    // regardless of whether it was selected.
+    public class TestCalculatedFields
+    {
+        [Fact]
+        public void Concat_MixesStringAndInt()
+        {
+            var node = new Concat(new[] { new[] { "a", "b", "c" } }, "result");
+            var variables = new Dictionary<string, object>
+            {
+                ["a"] = "Order-",
+                ["b"] = 42,
+                ["c"] = " (priority)",
+            };
+
+            node.Execute(ref variables, TimeSpan.Zero, null, null, null);
+
+            Assert.Equal("Order-42 (priority)", variables["result"]);
+        }
+
+        [Fact]
+        public void Concat_MixesStringAndDecimal()
+        {
+            var node = new Concat(new[] { new[] { "a", "b" } }, "result");
+            var variables = new Dictionary<string, object>
+            {
+                ["a"] = "Total: ",
+                ["b"] = 12.5m,
+            };
+
+            node.Execute(ref variables, TimeSpan.Zero, null, null, null);
+
+            Assert.Equal("Total: 12.5", variables["result"]);
+        }
+
+        [Fact]
+        public void Concat_TreatsNullAsEmpty()
+        {
+            var node = new Concat(new[] { new[] { "a", "b", "c" } }, "result");
+            var variables = new Dictionary<string, object>
+            {
+                ["a"] = "Start",
+                ["b"] = null,
+                ["c"] = "End",
+            };
+
+            node.Execute(ref variables, TimeSpan.Zero, null, null, null);
+
+            Assert.Equal("StartEnd", variables["result"]);
+        }
+    }
+}


### PR DESCRIPTION
The classic calculated-field Concat workflow node cast every operand
with `(string)`, throwing InvalidCastException whenever a non-string
column (int, decimal, money, ...) was concatenated with a string. The
error fired during every Retrieve/RetrieveMultiple because calculated
fields were evaluated on each row even when the column was not in the
ColumnSet.

- Stringify Concat operands instead of casting (invariant culture).
- Pass the set of needed columns to ExecuteCalculatedFields/
  ExecuteFormulaFields so unselected computed columns are skipped.
  Calc fields honour ColumnSet ∪ criteria/orders/link-from attrs (they
  are projected before filtering); formula fields honour the ColumnSet.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>