### PR TITLE
Plugin Trace Log implementation

### DIFF
--- a/src/XrmMockup365/Core.cs
+++ b/src/XrmMockup365/Core.cs
@@ -837,6 +837,36 @@ namespace DG.Tools.XrmMockup
             return new MockupServiceProviderAndFactory(this, pluginContext, TracingServiceFactory);
         }
 
+        private readonly List<PluginTraceLog> _pluginTraceLogs = new List<PluginTraceLog>();
+        private readonly object _pluginTraceLogLock = new object();
+
+        public void RecordPluginTrace(PluginTraceLog log)
+        {
+            lock (_pluginTraceLogLock)
+            {
+                _pluginTraceLogs.Add(log);
+            }
+        }
+
+        internal IReadOnlyList<PluginTraceLog> PluginTraceLogs
+        {
+            get
+            {
+                lock (_pluginTraceLogLock)
+                {
+                    return _pluginTraceLogs.ToList();
+                }
+            }
+        }
+
+        internal void ClearPluginTraceLogs()
+        {
+            lock (_pluginTraceLogLock)
+            {
+                _pluginTraceLogs.Clear();
+            }
+        }
+
         // ──────────────────────────────────────────────────────────────────────────
 
         internal void AddTime(TimeSpan offset)
@@ -1116,6 +1146,7 @@ namespace DG.Tools.XrmMockup
             this.TimeOffset = new TimeSpan();
             workflowManager.ResetWorkflows(settings.IncludeAllWorkflows);
 
+            ClearPluginTraceLogs();
             pluginManager.ResetPlugins();
             this.db = new XrmDb(metadata.EntityMetadata, OnlineDataService);
             this.RequestHandlers = GetRequestHandlers(db);

--- a/src/XrmMockup365/Internal/ICoreOperations.cs
+++ b/src/XrmMockup365/Internal/ICoreOperations.cs
@@ -55,6 +55,9 @@ namespace DG.Tools.XrmMockup.Internal
         ITracingServiceFactory TracingServiceFactory { get; }
         MockupServiceProviderAndFactory CreateServiceProviderAndFactory(PluginContext pluginContext);
 
+        // Grouped trace log — PluginTrigger records one entry per plugin execution
+        void RecordPluginTrace(PluginTraceLog log);
+
         // Settings — used by WorkflowManager
         XrmMockupSettings GetMockupSettings();
     }

--- a/src/XrmMockup365/Plugin/CustomApiManager.cs
+++ b/src/XrmMockup365/Plugin/CustomApiManager.cs
@@ -156,8 +156,20 @@ namespace DG.Tools.XrmMockup
             thisPluginContext.Mode = 0;
 
             var serviceProvider = new MockupServiceProviderAndFactory(_core, thisPluginContext, _core.TracingServiceFactory);
-            registeredApis[request.RequestName](serviceProvider);
-            
+            var api = registeredApis[request.RequestName];
+            PluginTraceRecorder.Run(
+                _core,
+                serviceProvider,
+                thisPluginContext,
+                typeName: api.Target?.GetType().FullName,
+                messageName: request.RequestName,
+                primaryEntity: thisPluginContext.PrimaryEntityName,
+                operationType: PluginTraceOperationType.Plugin,
+                mode: XrmPluginCore.Enums.ExecutionMode.Synchronous,
+                execute: () => api(serviceProvider),
+                unwrapTargetInvocation: false,
+                record: true);
+
             pluginContext.OutputParameters.Clear();
             pluginContext.OutputParameters.AddRange(thisPluginContext.OutputParameters);
 

--- a/src/XrmMockup365/Plugin/PluginManager.cs
+++ b/src/XrmMockup365/Plugin/PluginManager.cs
@@ -473,7 +473,9 @@ namespace DG.Tools.XrmMockup
                 return;
             }
 
-            plugins.ForEach(p => p.ExecuteIfMatch(entity, preImage, postImage, pluginContext, _core));
+            // System plugins are XrmMockup's own internal simulation, not user-registered steps,
+            // so they are excluded from the grouped plugin trace log.
+            plugins.ForEach(p => p.ExecuteIfMatch(entity, preImage, postImage, pluginContext, _core, recordTrace: false));
         }
 
         private string GeneratePluginCacheKey(IEnumerable<Type> basePluginTypes, IEnumerable<MetaPlugin> plugins)

--- a/src/XrmMockup365/Plugin/PluginTraceRecorder.cs
+++ b/src/XrmMockup365/Plugin/PluginTraceRecorder.cs
@@ -1,0 +1,83 @@
+using DG.Tools.XrmMockup.Internal;
+using Microsoft.Xrm.Sdk;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.ExceptionServices;
+using XrmPluginCore.Enums;
+
+namespace DG.Tools.XrmMockup
+{
+    /// <summary>
+    /// Shared helper that runs a plugin, custom API or workflow execution while timing it and
+    /// capturing any thrown exception, then records a grouped <see cref="PluginTraceLog"/> entry
+    /// built from that execution's own trace messages together with the supplied metadata.
+    /// </summary>
+    internal static class PluginTraceRecorder
+    {
+        /// <param name="unwrapTargetInvocation">
+        /// When true, a <see cref="TargetInvocationException"/> is unwrapped and its inner exception
+        /// rethrown, preserving the plugin pipeline's historical behavior.
+        /// </param>
+        /// <param name="record">When false, the execution still runs but no trace entry is recorded (e.g. internal system plugins).</param>
+        public static void Run(
+            ICoreOperations core,
+            MockupServiceProviderAndFactory provider,
+            PluginContext ctx,
+            string typeName,
+            string messageName,
+            string primaryEntity,
+            PluginTraceOperationType operationType,
+            ExecutionMode mode,
+            Action execute,
+            bool unwrapTargetInvocation,
+            bool record)
+        {
+            var startTime = DateTime.UtcNow.Add(core.TimeOffset);
+            var stopwatch = Stopwatch.StartNew();
+            string exceptionDetails = null;
+            try
+            {
+                execute();
+            }
+            catch (TargetInvocationException e) when (unwrapTargetInvocation)
+            {
+                exceptionDetails = (e.InnerException ?? e).ToString();
+                ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+            }
+            catch (Exception e)
+            {
+                exceptionDetails = e.ToString();
+                throw;
+            }
+            finally
+            {
+                stopwatch.Stop();
+                if (record)
+                {
+                    var messages = (provider.GetService<ITracingService>() as TracingService)?.Messages.ToList()
+                        ?? new List<string>();
+
+                    core.RecordPluginTrace(new PluginTraceLog
+                    {
+                        TypeName = typeName,
+                        MessageName = messageName,
+                        PrimaryEntity = string.IsNullOrEmpty(primaryEntity) ? "none" : primaryEntity,
+                        OperationType = operationType,
+                        Depth = ctx.Depth,
+                        CorrelationId = ctx.CorrelationId,
+                        Mode = mode,
+                        RequestId = ctx.RequestId,
+                        ExecutionStartTime = startTime,
+                        ExecutionDurationMs = stopwatch.Elapsed.TotalMilliseconds,
+                        MessageBlock = messages,
+                        ExceptionDetails = exceptionDetails,
+                        // Configuration, SecureConfiguration and PluginStepId are not modeled by XrmMockup.
+                    });
+                }
+            }
+        }
+    }
+}

--- a/src/XrmMockup365/Plugin/PluginTraceRecorder.cs
+++ b/src/XrmMockup365/Plugin/PluginTraceRecorder.cs
@@ -44,8 +44,11 @@ namespace DG.Tools.XrmMockup
             }
             catch (TargetInvocationException e) when (unwrapTargetInvocation)
             {
-                exceptionDetails = (e.InnerException ?? e).ToString();
-                ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+                // Fall back to the TargetInvocationException itself when there is no inner
+                // exception, so Capture is never handed null (which would mask the failure).
+                var toThrow = e.InnerException ?? (Exception)e;
+                exceptionDetails = toThrow.ToString();
+                ExceptionDispatchInfo.Capture(toThrow).Throw();
             }
             catch (Exception e)
             {

--- a/src/XrmMockup365/Plugin/PluginTrigger.cs
+++ b/src/XrmMockup365/Plugin/PluginTrigger.cs
@@ -75,13 +75,18 @@ namespace DG.Tools.XrmMockup
             {
                 // Create the plugin context
                 var thisPluginContext = CreatePluginContext(pluginContext, guid, logicalName, preImage, postImage);
-                return new PluginExecutionProvider(PluginExecute, core.CreateServiceProviderAndFactory(thisPluginContext));
+                var provider = core.CreateServiceProviderAndFactory(thisPluginContext);
+                // Preserve async exception semantics (no TargetInvocationException unwrapping), but
+                // still time the execution and capture its trace messages into the grouped trace log.
+                return new PluginExecutionProvider(
+                    p => ExecuteAndRecord(p, thisPluginContext, core, unwrapTargetInvocation: false, record: true),
+                    provider);
             }
 
             return null;
         }
 
-        public void ExecuteIfMatch(object entityObject, Entity preImage, Entity postImage, PluginContext pluginContext, ICoreOperations core)
+        public void ExecuteIfMatch(object entityObject, Entity preImage, Entity postImage, PluginContext pluginContext, ICoreOperations core, bool recordTrace = true)
         {
             // Check if it is supposed to execute. Returns preemptively, if it should not.
             var entity = entityObject as Entity;
@@ -107,20 +112,70 @@ namespace DG.Tools.XrmMockup
 
                 //Create Serviceprovider, and execute plugin
                 MockupServiceProviderAndFactory provider = core.CreateServiceProviderAndFactory(thisPluginContext);
-                try
-                {
-                    PluginExecute(provider);
-                }
-                catch (TargetInvocationException e)
-                {
-                    ExceptionDispatchInfo.Capture(e.InnerException).Throw();
-                }
+                ExecuteAndRecord(provider, thisPluginContext, core, unwrapTargetInvocation: true, record: recordTrace);
 
                 foreach (var parameter in thisPluginContext.SharedVariables)
                 {
                     pluginContext.SharedVariables[parameter.Key] = parameter.Value;
                 }
             }
+        }
+
+        /// <summary>
+        /// Executes the plugin while timing it and capturing any thrown exception, then (when
+        /// <paramref name="record"/> is true) records a grouped <see cref="PluginTraceLog"/> entry
+        /// containing this execution's trace messages and metadata.
+        /// </summary>
+        private void ExecuteAndRecord(MockupServiceProviderAndFactory provider, PluginContext ctx, ICoreOperations core, bool unwrapTargetInvocation, bool record)
+        {
+            var startTime = DateTime.UtcNow.Add(core.TimeOffset);
+            var stopwatch = Stopwatch.StartNew();
+            string exceptionDetails = null;
+            try
+            {
+                PluginExecute(provider);
+            }
+            catch (TargetInvocationException e) when (unwrapTargetInvocation)
+            {
+                exceptionDetails = (e.InnerException ?? e).ToString();
+                ExceptionDispatchInfo.Capture(e.InnerException).Throw();
+            }
+            catch (Exception e)
+            {
+                exceptionDetails = e.ToString();
+                throw;
+            }
+            finally
+            {
+                stopwatch.Stop();
+                if (record)
+                {
+                    RecordTrace(provider, ctx, startTime, stopwatch.Elapsed.TotalMilliseconds, exceptionDetails, core);
+                }
+            }
+        }
+
+        private void RecordTrace(MockupServiceProviderAndFactory provider, PluginContext ctx, DateTime startTime, double durationMs, string exceptionDetails, ICoreOperations core)
+        {
+            var messages = (provider.GetService<ITracingService>() as TracingService)?.Messages.ToList()
+                ?? new List<string>();
+
+            core.RecordPluginTrace(new PluginTraceLog
+            {
+                TypeName = PluginExecute.Target?.GetType().FullName,
+                MessageName = !string.IsNullOrEmpty(ctx.MessageName) ? ctx.MessageName : Operation,
+                PrimaryEntity = string.IsNullOrEmpty(ctx.PrimaryEntityName) ? "none" : ctx.PrimaryEntityName,
+                OperationType = PluginTraceOperationType.Plugin,
+                Depth = ctx.Depth,
+                CorrelationId = ctx.CorrelationId,
+                Mode = this.Mode,
+                RequestId = ctx.RequestId,
+                ExecutionStartTime = startTime,
+                ExecutionDurationMs = durationMs,
+                MessageBlock = messages,
+                ExceptionDetails = exceptionDetails,
+                // Configuration, SecureConfiguration and PluginStepId are not modeled by XrmMockup.
+            });
         }
 
         private void CheckInfiniteLoop(PluginContext pluginContext)

--- a/src/XrmMockup365/Plugin/PluginTrigger.cs
+++ b/src/XrmMockup365/Plugin/PluginTrigger.cs
@@ -128,54 +128,18 @@ namespace DG.Tools.XrmMockup
         /// </summary>
         private void ExecuteAndRecord(MockupServiceProviderAndFactory provider, PluginContext ctx, ICoreOperations core, bool unwrapTargetInvocation, bool record)
         {
-            var startTime = DateTime.UtcNow.Add(core.TimeOffset);
-            var stopwatch = Stopwatch.StartNew();
-            string exceptionDetails = null;
-            try
-            {
-                PluginExecute(provider);
-            }
-            catch (TargetInvocationException e) when (unwrapTargetInvocation)
-            {
-                exceptionDetails = (e.InnerException ?? e).ToString();
-                ExceptionDispatchInfo.Capture(e.InnerException).Throw();
-            }
-            catch (Exception e)
-            {
-                exceptionDetails = e.ToString();
-                throw;
-            }
-            finally
-            {
-                stopwatch.Stop();
-                if (record)
-                {
-                    RecordTrace(provider, ctx, startTime, stopwatch.Elapsed.TotalMilliseconds, exceptionDetails, core);
-                }
-            }
-        }
-
-        private void RecordTrace(MockupServiceProviderAndFactory provider, PluginContext ctx, DateTime startTime, double durationMs, string exceptionDetails, ICoreOperations core)
-        {
-            var messages = (provider.GetService<ITracingService>() as TracingService)?.Messages.ToList()
-                ?? new List<string>();
-
-            core.RecordPluginTrace(new PluginTraceLog
-            {
-                TypeName = PluginExecute.Target?.GetType().FullName,
-                MessageName = !string.IsNullOrEmpty(ctx.MessageName) ? ctx.MessageName : Operation,
-                PrimaryEntity = string.IsNullOrEmpty(ctx.PrimaryEntityName) ? "none" : ctx.PrimaryEntityName,
-                OperationType = PluginTraceOperationType.Plugin,
-                Depth = ctx.Depth,
-                CorrelationId = ctx.CorrelationId,
-                Mode = this.Mode,
-                RequestId = ctx.RequestId,
-                ExecutionStartTime = startTime,
-                ExecutionDurationMs = durationMs,
-                MessageBlock = messages,
-                ExceptionDetails = exceptionDetails,
-                // Configuration, SecureConfiguration and PluginStepId are not modeled by XrmMockup.
-            });
+            PluginTraceRecorder.Run(
+                core,
+                provider,
+                ctx,
+                typeName: PluginExecute.Target?.GetType().FullName,
+                messageName: !string.IsNullOrEmpty(ctx.MessageName) ? ctx.MessageName : Operation,
+                primaryEntity: ctx.PrimaryEntityName,
+                operationType: PluginTraceOperationType.Plugin,
+                mode: this.Mode,
+                execute: () => PluginExecute(provider),
+                unwrapTargetInvocation: unwrapTargetInvocation,
+                record: record);
         }
 
         private void CheckInfiniteLoop(PluginContext pluginContext)

--- a/src/XrmMockup365/PluginTraceLog.cs
+++ b/src/XrmMockup365/PluginTraceLog.cs
@@ -1,0 +1,85 @@
+using System;
+using System.Collections.Generic;
+using XrmPluginCore.Enums;
+
+namespace DG.Tools.XrmMockup
+{
+    /// <summary>
+    /// The type of operation that produced a <see cref="PluginTraceLog"/>, mirroring the
+    /// OperationType option set on the platform's plugintracelog entity.
+    /// </summary>
+    public enum PluginTraceOperationType
+    {
+        Unknown = 0,
+        Plugin = 1,
+        WorkflowActivity = 2,
+    }
+
+    /// <summary>
+    /// A single grouped trace-log entry, capturing all trace messages emitted by one
+    /// plugin (or workflow activity) execution together with the metadata identifying it,
+    /// mirroring the plugintracelog records produced by a real Dynamics 365 environment.
+    /// </summary>
+    public sealed class PluginTraceLog
+    {
+        /// <summary>The full name of the invoking type, e.g. the plugin class.</summary>
+        public string TypeName { get; internal set; }
+
+        /// <summary>The message being processed, e.g. Create, Update or a custom API name.</summary>
+        public string MessageName { get; internal set; }
+
+        /// <summary>The primary entity of the operation, or "none" if there is no bound entity.</summary>
+        public string PrimaryEntity { get; internal set; }
+
+        /// <summary>
+        /// The unsecure configuration supplied to the plugin step.
+        /// <para>Not currently modeled by XrmMockup and therefore always null.</para>
+        /// </summary>
+        public string Configuration { get; internal set; }
+
+        /// <summary>
+        /// The secure configuration supplied to the plugin step.
+        /// <para>Not currently modeled by XrmMockup and therefore always null.</para>
+        /// </summary>
+        public string SecureConfiguration { get; internal set; }
+
+        /// <summary>Whether the entry originated from a plugin or a workflow activity.</summary>
+        public PluginTraceOperationType OperationType { get; internal set; }
+
+        /// <summary>
+        /// The id of the plugin step (SDK message processing step) that was executed.
+        /// <para>Not currently modeled by XrmMockup and therefore always null.</para>
+        /// </summary>
+        public Guid? PluginStepId { get; internal set; }
+
+        /// <summary>The execution depth: 1 for a directly invoked plugin, 2 for a plugin invoked by a plugin, etc.</summary>
+        public int Depth { get; internal set; }
+
+        /// <summary>The correlation id shared across the whole execution chain.</summary>
+        public Guid CorrelationId { get; internal set; }
+
+        /// <summary>Whether the execution was synchronous or asynchronous.</summary>
+        public ExecutionMode Mode { get; internal set; }
+
+        /// <summary>The id of the request that triggered the execution, if available.</summary>
+        public Guid? RequestId { get; internal set; }
+
+        /// <summary>The time at which execution started, according to the mockup's (possibly offset) clock.</summary>
+        public DateTime ExecutionStartTime { get; internal set; }
+
+        /// <summary>The wall-clock duration of the execution, in milliseconds.</summary>
+        public double ExecutionDurationMs { get; internal set; }
+
+        /// <summary>
+        /// The trace messages emitted during the execution, in order. This is the platform's
+        /// "Message Block", kept as a list rather than a single concatenated string.
+        /// </summary>
+        public IReadOnlyList<string> MessageBlock { get; internal set; } = new List<string>();
+
+        /// <summary>The message and stack trace of the exception that ended the execution, or null if it succeeded.</summary>
+        public string ExceptionDetails { get; internal set; }
+
+        /// <summary>The <see cref="MessageBlock"/> joined into a single string, matching the platform's concatenated block.</summary>
+        public string MessageBlockText => string.Join(Environment.NewLine, MessageBlock ?? new List<string>());
+    }
+}

--- a/src/XrmMockup365/TracingService.cs
+++ b/src/XrmMockup365/TracingService.cs
@@ -22,7 +22,7 @@ namespace DG.Tools.XrmMockup
 		/// service is created per plugin/workflow execution, this scopes the messages to that
 		/// single execution and lets them be grouped into a <see cref="PluginTraceLog"/>.
 		/// </summary>
-		public IReadOnlyList<string> Messages => _messages;
+		public IReadOnlyList<string> Messages => _messages.AsReadOnly();
 
 		public void Trace(string format, params object[] args)
 		{

--- a/src/XrmMockup365/TracingService.cs
+++ b/src/XrmMockup365/TracingService.cs
@@ -1,11 +1,13 @@
 using Microsoft.Xrm.Sdk;
 using System;
+using System.Collections.Generic;
 
 namespace DG.Tools.XrmMockup
 {
 	internal sealed class TracingService : ITracingService
 	{
 		private readonly Action<string> _sink;
+		private readonly List<string> _messages = new List<string>();
 
 		public TracingService() : this(null) { }
 
@@ -14,6 +16,13 @@ namespace DG.Tools.XrmMockup
 		{
 			_sink = sink;
 		}
+
+		/// <summary>
+		/// The trace messages emitted through this service instance, in order. Because a fresh
+		/// service is created per plugin/workflow execution, this scopes the messages to that
+		/// single execution and lets them be grouped into a <see cref="PluginTraceLog"/>.
+		/// </summary>
+		public IReadOnlyList<string> Messages => _messages;
 
 		public void Trace(string format, params object[] args)
 		{
@@ -27,6 +36,7 @@ namespace DG.Tools.XrmMockup
 				: string.Format(format, args);
 
 			Console.WriteLine(message);
+			_messages.Add(message);
 			_sink?.Invoke(message);
 		}
 	}

--- a/src/XrmMockup365/TracingService.cs
+++ b/src/XrmMockup365/TracingService.cs
@@ -1,20 +1,33 @@
-﻿using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk;
 using System;
 
 namespace DG.Tools.XrmMockup
 {
 	internal sealed class TracingService : ITracingService
 	{
+		private readonly Action<string> _sink;
+
+		public TracingService() : this(null) { }
+
+		/// <param name="sink">Optional callback invoked with each fully-evaluated trace message, allowing a consumer to collect them for assertions.</param>
+		public TracingService(Action<string> sink)
+		{
+			_sink = sink;
+		}
+
 		public void Trace(string format, params object[] args)
 		{
-			try
-			{
-				Console.WriteLine(format, args);
-			}
-			catch
-			{
-				Console.WriteLine(format);
-			}
+			// Match the platform's sandbox tracing service: a message supplied without
+			// arguments is emitted verbatim (so literal braces in e.g. XML/HTML are fine),
+			// while a message with arguments is evaluated through String.Format. We do NOT
+			// swallow a resulting FormatException, so invalid format strings surface during
+			// testing instead of silently slipping through to production.
+			var message = (args == null || args.Length == 0)
+				? format
+				: string.Format(format, args);
+
+			Console.WriteLine(message);
+			_sink?.Invoke(message);
 		}
 	}
 }

--- a/src/XrmMockup365/TracingServiceFactory.cs
+++ b/src/XrmMockup365/TracingServiceFactory.cs
@@ -1,5 +1,7 @@
 using Microsoft.Xrm.Sdk;
 using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace DG.Tools.XrmMockup
 {
@@ -10,6 +12,42 @@ namespace DG.Tools.XrmMockup
 
     internal class TracingServiceFactory : ITracingServiceFactory
     {
-        public ITracingService GetService() => new TracingService();
+        private readonly List<string> _messages = new List<string>();
+        private readonly object _lock = new object();
+
+        public ITracingService GetService() => new TracingService(Record);
+
+        private void Record(string message)
+        {
+            lock (_lock)
+            {
+                _messages.Add(message);
+            }
+        }
+
+        /// <summary>
+        /// A snapshot of all trace messages emitted through services created by this factory.
+        /// </summary>
+        public IReadOnlyList<string> TraceLog
+        {
+            get
+            {
+                lock (_lock)
+                {
+                    return _messages.ToList();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Clears all collected trace messages.
+        /// </summary>
+        public void Clear()
+        {
+            lock (_lock)
+            {
+                _messages.Clear();
+            }
+        }
     }
 }

--- a/src/XrmMockup365/Workflow/WorkflowManager.cs
+++ b/src/XrmMockup365/Workflow/WorkflowManager.cs
@@ -123,7 +123,7 @@ namespace DG.Tools.XrmMockup {
             {
                 Entity primaryEntity = _core.GetDbRow(workflowContext.primaryRef).ToEntity();
 
-                var execution = ExecuteWorkflow(workflowContext.workflow, primaryEntity, workflowContext.pluginContext);
+                var execution = ExecuteWorkflow(workflowContext.workflow, primaryEntity, workflowContext.pluginContext, workflowContext.workflowName);
 
                 if (execution.Variables["Wait"] != null)
                 {
@@ -166,12 +166,14 @@ namespace DG.Tools.XrmMockup {
             public WorkflowTree workflow;
             public PluginContext pluginContext;
             public EntityReference primaryRef;
+            public string workflowName;
 
-            public WorkflowExecutionContext(WorkflowTree workflow,PluginContext pluginContext, EntityReference primaryRef)
+            public WorkflowExecutionContext(WorkflowTree workflow,PluginContext pluginContext, EntityReference primaryRef, string workflowName = null)
             {
                 this.workflow = workflow;
                 this.pluginContext = pluginContext;
                 this.primaryRef = primaryRef;
+                this.workflowName = workflowName;
             }
         }
 
@@ -243,7 +245,7 @@ namespace DG.Tools.XrmMockup {
             var parsedWorkflow = ParseWorkflow(workflow);
             if (parsedWorkflow == null) return;
 
-            pendingAsyncWorkflows.Enqueue(new WorkflowExecutionContext(parsedWorkflow, thisPluginContext, new EntityReference(logicalName, guid)));
+            pendingAsyncWorkflows.Enqueue(new WorkflowExecutionContext(parsedWorkflow, thisPluginContext, new EntityReference(logicalName, guid), workflow.GetAttributeValue<string>("name")));
         }
 
         private bool ShouldStage(Entity workflow, string operation, ExecutionStage stage,
@@ -391,13 +393,14 @@ namespace DG.Tools.XrmMockup {
             var parsedWorkflow = ParseWorkflow(workflow);
 
             WorkflowTree postExecution = null;
+            var workflowName = workflow.GetAttributeValue<string>("name");
             if (thisStage == workflow_stage.Preoperation)
             {
-                postExecution = ExecuteWorkflow(parsedWorkflow, preImage.CloneEntity(), thisPluginContext);
+                postExecution = ExecuteWorkflow(parsedWorkflow, preImage.CloneEntity(), thisPluginContext, workflowName);
             }
             else
             {
-                postExecution = ExecuteWorkflow(parsedWorkflow, postImage.CloneEntity(), thisPluginContext);
+                postExecution = ExecuteWorkflow(parsedWorkflow, postImage.CloneEntity(), thisPluginContext, workflowName);
             }
 
             if (postExecution.Variables["Wait"] != null)
@@ -406,11 +409,27 @@ namespace DG.Tools.XrmMockup {
             }
         }
 
-        internal WorkflowTree ExecuteWorkflow(WorkflowTree workflow, Entity primaryEntity, PluginContext pluginContext) {
+        internal WorkflowTree ExecuteWorkflow(WorkflowTree workflow, Entity primaryEntity, PluginContext pluginContext, string workflowName = null) {
             var provider = _core.CreateServiceProviderAndFactory(pluginContext);
             var triggerWorkflows = _core.GetMockupSettings().TriggerWorkflows ?? true;
             var service = provider.CreateAdminOrganizationService(new MockupServiceSettings(true, triggerWorkflows, true, MockupServiceSettings.Role.SDK));
-            return workflow.Execute(primaryEntity, _core.TimeOffset, service, provider, provider.GetService<ITracingService>());
+
+            WorkflowTree result = null;
+            // A null plugin context indicates a directly-invoked workflow/action (ExecuteWorkflowRequest);
+            // without context metadata we run it but skip recording a grouped trace entry.
+            PluginTraceRecorder.Run(
+                _core,
+                provider,
+                pluginContext,
+                typeName: workflowName,
+                messageName: pluginContext?.MessageName,
+                primaryEntity: pluginContext?.PrimaryEntityName ?? primaryEntity?.LogicalName,
+                operationType: PluginTraceOperationType.WorkflowActivity,
+                mode: pluginContext != null ? (ExecutionMode)pluginContext.Mode : ExecutionMode.Synchronous,
+                execute: () => result = workflow.Execute(primaryEntity, _core.TimeOffset, service, provider, provider.GetService<ITracingService>()),
+                unwrapTargetInvocation: false,
+                record: pluginContext != null);
+            return result;
         }
 
         internal WorkflowTree ParseWorkflow(Entity workflow) {

--- a/src/XrmMockup365/XrmMockupBase.cs
+++ b/src/XrmMockup365/XrmMockupBase.cs
@@ -56,6 +56,21 @@ namespace DG.Tools.XrmMockup
         private readonly Dictionary<string, long> timers;
         public IReadOnlyDictionary<string, long> Timers => new ReadOnlyDictionary<string, long>(timers);
 
+        /// <summary>
+        /// A snapshot of the trace messages emitted to <see cref="ITracingService"/> during
+        /// plugin, workflow and custom API execution, allowing tests to assert on them.
+        /// <para>Only populated when using the default tracing service factory, i.e. when a
+        /// custom <see cref="XrmMockupSettings.TracingServiceFactory"/> has not been supplied.</para>
+        /// </summary>
+        public IReadOnlyList<string> TraceLog =>
+            (Core.TracingServiceFactory as TracingServiceFactory)?.TraceLog ?? new List<string>();
+
+        /// <summary>
+        /// Clears all collected trace messages from the <see cref="TraceLog"/>.
+        /// </summary>
+        public void ClearTraceLog() =>
+            (Core.TracingServiceFactory as TracingServiceFactory)?.Clear();
+
         protected XrmMockupSettings Settings { get; }
         protected MetadataSkeleton Metadata { get; }
         protected List<Entity> Workflows { get; }
@@ -190,6 +205,7 @@ namespace DG.Tools.XrmMockup
         /// </summary>
         public void ResetEnvironment() {
             Core.ResetEnvironment();
+            ClearTraceLog();
         }
 
 

--- a/src/XrmMockup365/XrmMockupBase.cs
+++ b/src/XrmMockup365/XrmMockupBase.cs
@@ -71,6 +71,20 @@ namespace DG.Tools.XrmMockup
         public void ClearTraceLog() =>
             (Core.TracingServiceFactory as TracingServiceFactory)?.Clear();
 
+        /// <summary>
+        /// The trace messages emitted during plugin execution, grouped by the plugin execution
+        /// that produced them, mirroring the plugintracelog records of a real Dynamics 365
+        /// environment. Each entry carries the invoking type, message, primary entity, depth,
+        /// correlation id, mode, timing, the ordered list of trace messages and any exception.
+        /// <para>Internal XrmMockup system plugins are excluded.</para>
+        /// </summary>
+        public IReadOnlyList<PluginTraceLog> PluginTraceLog => Core.PluginTraceLogs;
+
+        /// <summary>
+        /// Clears all collected <see cref="PluginTraceLog"/> entries.
+        /// </summary>
+        public void ClearPluginTraceLog() => Core.ClearPluginTraceLogs();
+
         protected XrmMockupSettings Settings { get; }
         protected MetadataSkeleton Metadata { get; }
         protected List<Entity> Workflows { get; }

--- a/src/XrmMockup365/XrmMockupBase.cs
+++ b/src/XrmMockup365/XrmMockupBase.cs
@@ -63,7 +63,7 @@ namespace DG.Tools.XrmMockup
         /// custom <see cref="XrmMockupSettings.TracingServiceFactory"/> has not been supplied.</para>
         /// </summary>
         public IReadOnlyList<string> TraceLog =>
-            (Core.TracingServiceFactory as TracingServiceFactory)?.TraceLog ?? new List<string>();
+            (Core.TracingServiceFactory as TracingServiceFactory)?.TraceLog ?? Array.Empty<string>();
 
         /// <summary>
         /// Clears all collected trace messages from the <see cref="TraceLog"/>.

--- a/tests/TestPluginAssembly365/CodeActivities/AccountWorkflowActivity.cs
+++ b/tests/TestPluginAssembly365/CodeActivities/AccountWorkflowActivity.cs
@@ -33,6 +33,7 @@ namespace DG.Some.Namespace {
                 as IOrganizationService;
 
             var accRef = name.Get(executionContext);
+            traceService.Trace("AccountWorkflowActivity executing for {0}", accRef.Id);
             var account = orgService.Retrieve(Account.EntityLogicalName, accRef.Id, new ColumnSet("name")) as Account;
             account.Name += "setFromCodeActivity";
             orgService.Update(account);

--- a/tests/TestPluginAssembly365/CustomApis/TraceApi.cs
+++ b/tests/TestPluginAssembly365/CustomApis/TraceApi.cs
@@ -1,0 +1,30 @@
+namespace DG.Some.Namespace {
+    using System;
+    using XrmPluginCore;
+    using XrmPluginCore.Enums;
+
+    /// <summary>
+    /// Custom API that emits trace messages, used to verify grouped trace-log capture for custom APIs.
+    /// Registered as dg_TraceApi.
+    /// </summary>
+    public class TraceApi : Plugin
+    {
+        public TraceApi()
+        {
+            RegisterCustomAPI("TraceApi", Execute)
+                .AddResponseProperty("Done", CustomApiParameterType.Boolean);
+        }
+
+        protected void Execute(LocalPluginContext localContext)
+        {
+            if (localContext == null)
+            {
+                throw new ArgumentNullException("localContext");
+            }
+
+            localContext.TracingService.Trace("TraceApi running");
+            localContext.TracingService.Trace("TraceApi step {0}", 2);
+            localContext.PluginExecutionContext.OutputParameters["Done"] = true;
+        }
+    }
+}

--- a/tests/TestPluginAssembly365/Plugins/AccountTracePlugin.cs
+++ b/tests/TestPluginAssembly365/Plugins/AccountTracePlugin.cs
@@ -1,0 +1,33 @@
+namespace DG.Some.Namespace {
+    using System;
+    using Microsoft.Xrm.Sdk;
+    using DG.XrmFramework.BusinessDomain.ServiceContext;
+    using TestPluginAssembly365.Plugins.SyncAsyncTest;
+    using XrmPluginCore;
+    using XrmPluginCore.Enums;
+
+    /// <summary>
+    /// Test plugin that emits trace messages during a post-Create operation.
+    /// Used to verify that XrmMockup collects trace messages and exposes them via TraceLog.
+    /// </summary>
+    public class AccountTracePlugin : TestPlugin {
+        public AccountTracePlugin() {
+#pragma warning disable CS0618 // Type or member is obsolete - disabled for testing purposes
+            RegisterPluginStep<Account>(
+                EventOperation.Create,
+                ExecutionStage.PostOperation,
+                Execute);
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        protected void Execute(LocalPluginContext localContext) {
+            if (localContext == null) {
+                throw new ArgumentNullException("localContext");
+            }
+
+            var target = (Entity)localContext.PluginExecutionContext.InputParameters["Target"];
+            localContext.TracingService.Trace("Creating account");
+            localContext.TracingService.Trace("Account name is {0}", target.GetAttributeValue<string>("name"));
+        }
+    }
+}

--- a/tests/TestPluginAssembly365/Plugins/AccountTraceThrowPlugin.cs
+++ b/tests/TestPluginAssembly365/Plugins/AccountTraceThrowPlugin.cs
@@ -1,0 +1,34 @@
+namespace DG.Some.Namespace {
+    using System;
+    using Microsoft.Xrm.Sdk;
+    using DG.XrmFramework.BusinessDomain.ServiceContext;
+    using TestPluginAssembly365.Plugins.SyncAsyncTest;
+    using XrmPluginCore;
+    using XrmPluginCore.Enums;
+
+    /// <summary>
+    /// Test plugin that traces and then throws, used to verify that XrmMockup captures
+    /// exception details in the grouped plugin trace log.
+    /// </summary>
+    public class AccountTraceThrowPlugin : TestPlugin {
+        public const string ThrowMessage = "AccountTraceThrowPlugin failed on purpose";
+
+        public AccountTraceThrowPlugin() {
+#pragma warning disable CS0618 // Type or member is obsolete - disabled for testing purposes
+            RegisterPluginStep<Account>(
+                EventOperation.Create,
+                ExecutionStage.PreOperation,
+                Execute);
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        protected void Execute(LocalPluginContext localContext) {
+            if (localContext == null) {
+                throw new ArgumentNullException("localContext");
+            }
+
+            localContext.TracingService.Trace("About to throw");
+            throw new InvalidPluginExecutionException(ThrowMessage);
+        }
+    }
+}

--- a/tests/XrmMockup365Test/TestTracingService.cs
+++ b/tests/XrmMockup365Test/TestTracingService.cs
@@ -58,5 +58,49 @@ namespace DG.XrmMockupTest
             crm.ClearTraceLog();
             Assert.Empty(crm.TraceLog);
         }
+
+        [Fact]
+        public void PluginTraceLogGroupsMessagesByExecutionWithMetadata()
+        {
+            crm.RegisterAdditionalPlugins(PluginRegistrationScope.Temporary, typeof(DG.Some.Namespace.AccountTracePlugin));
+            crm.ClearPluginTraceLog();
+
+            var account = new Account { Name = "Contoso" };
+            account.Id = orgAdminService.Create(account);
+
+            var entry = Assert.Single(crm.PluginTraceLog.Where(l => l.TypeName == typeof(DG.Some.Namespace.AccountTracePlugin).FullName));
+
+            Assert.Equal("Create", entry.MessageName);
+            Assert.Equal("account", entry.PrimaryEntity);
+            Assert.Equal(XrmPluginCore.Enums.ExecutionMode.Synchronous, entry.Mode);
+            Assert.Equal(PluginTraceOperationType.Plugin, entry.OperationType);
+            Assert.Equal(1, entry.Depth);
+            Assert.Null(entry.ExceptionDetails);
+
+            // Both Trace calls from this execution are grouped together, in order. (The plugin
+            // base class also emits its own Entered/Exiting trace messages around the handler.)
+            Assert.Contains("Creating account", entry.MessageBlock);
+            Assert.Contains("Account name is Contoso", entry.MessageBlock);
+            Assert.True(
+                entry.MessageBlock.ToList().IndexOf("Creating account") < entry.MessageBlock.ToList().IndexOf("Account name is Contoso"),
+                "Trace messages should be recorded in the order they were emitted");
+            Assert.Contains("Creating account", entry.MessageBlockText);
+        }
+
+        [Fact]
+        public void PluginTraceLogCapturesExceptionDetails()
+        {
+            crm.RegisterAdditionalPlugins(PluginRegistrationScope.Temporary, typeof(DG.Some.Namespace.AccountTraceThrowPlugin));
+            crm.ClearPluginTraceLog();
+
+            var account = new Account { Name = "Contoso" };
+            Assert.ThrowsAny<System.Exception>(() => orgAdminService.Create(account));
+
+            var entry = Assert.Single(crm.PluginTraceLog.Where(l => l.TypeName == typeof(DG.Some.Namespace.AccountTraceThrowPlugin).FullName));
+
+            Assert.Contains("About to throw", entry.MessageBlock);
+            Assert.NotNull(entry.ExceptionDetails);
+            Assert.Contains(DG.Some.Namespace.AccountTraceThrowPlugin.ThrowMessage, entry.ExceptionDetails);
+        }
     }
 }

--- a/tests/XrmMockup365Test/TestTracingService.cs
+++ b/tests/XrmMockup365Test/TestTracingService.cs
@@ -2,6 +2,7 @@
 using Xunit;
 using Microsoft.Xrm.Sdk;
 using DG.Tools.XrmMockup;
+using System.Linq;
 
 namespace DG.XrmMockupTest
 {
@@ -14,6 +15,48 @@ namespace DG.XrmMockupTest
         {
             ITracingService trace = new TracingService();
             trace.Trace("cams_signatures : <head><style type=text/css>p,li{font-family: Arial,Helvetica,sans-serif;font-size: 11pt;}</style></head><body><p contenteditable=\"false\"><span style=\font - family: Arial; font - size: 11pt; \">By signing the Agreement Plan, the signatories are certifying, subject to the exceptions detailed below, both the completeness of the Agreement Plan and the agreed commitment between [CUSTOMER] and [DELIVERY AGENT].</span></p></body>");
+        }
+
+        [Fact]
+        public void TracingServiceShouldEvaluateFormatStringWithArgs()
+        {
+            ITracingService trace = new TracingService();
+            trace.Trace("Value is {0} and {1}", 42, "test");
+        }
+
+        [Fact]
+        public void TracingServiceShouldThrowOnInvalidFormatStringWithArgs()
+        {
+            ITracingService trace = new TracingService();
+            // Referencing an argument index that isn't supplied would throw a FormatException
+            // in a real environment; the mockup must surface it rather than swallow it.
+            Assert.Throws<System.FormatException>(() => trace.Trace("Value is {1}", 42));
+        }
+
+        [Fact]
+        public void TraceMessagesAreCollectedAndExposedForAssertions()
+        {
+            crm.RegisterAdditionalPlugins(PluginRegistrationScope.Temporary, typeof(DG.Some.Namespace.AccountTracePlugin));
+            crm.ClearTraceLog();
+
+            var account = new Account { Name = "Contoso" };
+            account.Id = orgAdminService.Create(account);
+
+            Assert.Contains("Creating account", crm.TraceLog);
+            Assert.Contains("Account name is Contoso", crm.TraceLog);
+        }
+
+        [Fact]
+        public void ClearTraceLogEmptiesCollectedMessages()
+        {
+            crm.RegisterAdditionalPlugins(PluginRegistrationScope.Temporary, typeof(DG.Some.Namespace.AccountTracePlugin));
+
+            var account = new Account { Name = "Contoso" };
+            account.Id = orgAdminService.Create(account);
+            Assert.NotEmpty(crm.TraceLog);
+
+            crm.ClearTraceLog();
+            Assert.Empty(crm.TraceLog);
         }
     }
 }

--- a/tests/XrmMockup365Test/TestTracingService.cs
+++ b/tests/XrmMockup365Test/TestTracingService.cs
@@ -102,5 +102,38 @@ namespace DG.XrmMockupTest
             Assert.NotNull(entry.ExceptionDetails);
             Assert.Contains(DG.Some.Namespace.AccountTraceThrowPlugin.ThrowMessage, entry.ExceptionDetails);
         }
+
+        [Fact]
+        public void PluginTraceLogCapturesCustomApiExecution()
+        {
+            crm.ClearPluginTraceLog();
+
+            orgAdminService.Execute(new OrganizationRequest("dg_TraceApi"));
+
+            var entry = Assert.Single(crm.PluginTraceLog.Where(l => l.TypeName == typeof(DG.Some.Namespace.TraceApi).FullName));
+
+            Assert.Equal("dg_TraceApi", entry.MessageName);
+            Assert.Equal(PluginTraceOperationType.Plugin, entry.OperationType);
+            Assert.Equal(XrmPluginCore.Enums.ExecutionMode.Synchronous, entry.Mode);
+            Assert.Contains("TraceApi running", entry.MessageBlock);
+            Assert.Contains("TraceApi step 2", entry.MessageBlock);
+            Assert.Null(entry.ExceptionDetails);
+        }
+
+        [Fact]
+        public void PluginTraceLogCapturesWorkflowActivityExecution()
+        {
+            crm.AddWorkflow(System.IO.Path.Combine("../../..", "Metadata", "OtherWorkflows", "Activeworkflow.xml"));
+            crm.ClearPluginTraceLog();
+
+            var account = new Account { Name = "Wap" };
+            account.Id = orgAdminUIService.Create(account);
+
+            var entry = Assert.Single(crm.PluginTraceLog.Where(l => l.OperationType == PluginTraceOperationType.WorkflowActivity));
+
+            Assert.Equal("account", entry.PrimaryEntity);
+            Assert.Contains(entry.MessageBlock, m => m.StartsWith("AccountWorkflowActivity executing for"));
+            Assert.Null(entry.ExceptionDetails);
+        }
     }
 }


### PR DESCRIPTION
## Evaluate ITracingService messages via String.Format and expose collected trace log
Trace messages with format args are now evaluated through String.Format so
invalid format strings surface during testing instead of being silently
swallowed. Arg-less messages remain verbatim, matching platform behavior.

Trace messages are also collected by the default tracing service factory and
exposed via XrmMockupBase.TraceLog (with ClearTraceLog) so tests can assert on
emitted trace output.

## Group trace messages per plugin execution via PluginTraceLog
Trace messages are now grouped by the plugin execution that produced them,
mirroring the plugintracelog records of a real Dynamics 365 environment. Each
XrmMockupBase.PluginTraceLog entry captures the invoking type, message name,
primary entity, operation type, depth, correlation id, mode, request id,
execution start time, duration, the ordered list of trace messages and any
exception details.

PluginTrigger now times each sync/async plugin execution, captures thrown
exceptions and records an entry with the execution's own trace messages.
Internal XrmMockup system plugins are excluded. Configuration/secure
configuration and plugin step ids are not modeled by XrmMockup and remain null.

## Extend grouped trace log to custom APIs and workflow activities
The per-execution trace grouping introduced for plugins now also covers custom
API executions and workflow activity executions (sync and async). A shared
PluginTraceRecorder helper centralizes the timing, exception capture and trace
message collection used by all three paths; CustomApiManager and WorkflowManager
now route their executions through it.

Custom API entries record the request name as the message and Plugin operation
type; workflow entries record the workflow name as the type, WorkflowActivity
operation type and the workflow's sync/async mode. Directly-invoked workflows
(ExecuteWorkflowRequest, which has no plugin context) are executed but not logged.

Co-Authored-By: Claude <noreply@anthropic.com> via Conducktor <conducktor@contextand.com>