### PR TITLE
Align plugin Target with Dataverse for system-managed fields

### DIFF
--- a/src/XrmMockup365/Core.cs
+++ b/src/XrmMockup365/Core.cs
@@ -174,7 +174,15 @@ namespace DG.Tools.XrmMockup
                 workflowManager.AsynchronousWorkflowCount,
                 customApiManager.RegisteredApiCount);
 
-            systemAttributeNames = new List<string>() { "createdon", "createdby", "modifiedon", "modifiedby" };
+            // System-managed attributes that Dataverse resolves during the main operation. They are
+            // not present in the Target during the pre-stages, but are copied back onto the Target for
+            // post-operation plugins (and are always available via the post-image).
+            systemAttributeNames = new List<string>()
+            {
+                "createdon", "createdby", "modifiedon", "modifiedby",
+                "ownerid", "owningbusinessunit", "owninguser", "owningteam",
+                "statecode", "statuscode"
+            };
 
             RequestHandlers = GetRequestHandlers(db);
             InitializeDB();
@@ -785,15 +793,17 @@ namespace DG.Tools.XrmMockup
             {
                 if (postImage.Contains(systemAttributeName))
                 {
-                    if (postImage[systemAttributeName] is EntityReference)
+                    if (postImage[systemAttributeName] is EntityReference reference)
                     {
-                        target[systemAttributeName] = new EntityReference(
-                            postImage.GetAttributeValue<EntityReference>(systemAttributeName).LogicalName,
-                            postImage.GetAttributeValue<EntityReference>(systemAttributeName).Id);
+                        target[systemAttributeName] = new EntityReference(reference.LogicalName, reference.Id);
                     }
-                    else if (postImage[systemAttributeName] is DateTime)
+                    else if (postImage[systemAttributeName] is DateTime dateTime)
                     {
-                        target[systemAttributeName] = postImage.GetAttributeValue<DateTime>(systemAttributeName);
+                        target[systemAttributeName] = dateTime;
+                    }
+                    else if (postImage[systemAttributeName] is OptionSetValue optionSet)
+                    {
+                        target[systemAttributeName] = new OptionSetValue(optionSet.Value);
                     }
                 }
             }
@@ -807,11 +817,11 @@ namespace DG.Tools.XrmMockup
                 if (entity.Id == Guid.Empty)
                     entity.Id = Guid.NewGuid();
 
-                if (entity.GetAttributeValue<EntityReference>("ownerid") == null &&
-                    Utility.IsValidAttribute("ownerid", metadata.EntityMetadata.GetMetadata(entity.LogicalName)))
-                {
-                    entity["ownerid"] = userRef;
-                }
+                // Note: ownerid is intentionally NOT defaulted here. In Dataverse the owner is
+                // resolved during the main operation (stage 30), so it must not be visible in the
+                // Target during the PreValidation/PreOperation stages. The persisted default (calling
+                // user) is applied by CreateRequestHandler.Execute, and the resolved value surfaces
+                // afterwards via the post-image and the post-operation Target.
             }
         }
 

--- a/src/XrmMockup365/Requests/CreateRequestHandler.cs
+++ b/src/XrmMockup365/Requests/CreateRequestHandler.cs
@@ -32,6 +32,15 @@ namespace DG.Tools.XrmMockup
             clonedEntity.Attributes = new AttributeCollection();
             clonedEntity.Attributes.AddRange(validAttributes);
 
+            // Resolve the effective owner for the access checks only. The persisted default is applied in
+            // Execute and the plugin-visible Target is intentionally left without an ownerid, matching
+            // Dataverse. Ownership-based checks (e.g. user-level Append) need the effective owner here.
+            if (!clonedEntity.Attributes.ContainsKey("ownerid") &&
+                Utility.IsValidAttribute("ownerid", entityMetadata))
+            {
+                clonedEntity["ownerid"] = userRef;
+            }
+
             if (userRef != null && userRef.Id != Guid.Empty)
             {
                 if (!security.HasPermission(clonedEntity, AccessRights.CreateAccess, userRef))
@@ -75,45 +84,6 @@ namespace DG.Tools.XrmMockup
             }
         }
 
-        internal override void InitializePreOperation(OrganizationRequest orgRequest, EntityReference userRef, Entity preImage)
-        {
-            var entity = orgRequest["Target"] as Entity;
-            var logicalName = metadata.EntityMetadata.GetMetadata(entity.LogicalName);
-            var createdOn = DateTime.UtcNow.Add(core.TimeOffset);
-
-            if (Utility.IsValidAttribute("createdon", logicalName))
-            {
-                if (Utility.IsValidAttribute("overriddencreatedon", logicalName) && entity.Attributes.ContainsKey("overriddencreatedon") && entity["overriddencreatedon"] is DateTime overriddencreatedon)
-                {
-                    if (overriddencreatedon > createdOn)
-                    {
-                        throw new FaultException(
-                            $"Trying to create entity '{entity.LogicalName}', but overriddencreatedon cannot be set to a date in the future");
-                    }
-
-                    entity["overriddencreatedon"] = createdOn;
-                    createdOn = overriddencreatedon;
-                }
-
-                entity["createdon"] = createdOn;
-            }
-
-            if (Utility.IsValidAttribute("createdby", logicalName))
-            {
-                entity["createdby"] = userRef;
-            }
-
-            if (Utility.IsValidAttribute("modifiedon", logicalName))
-            {
-                entity["modifiedon"] = createdOn;
-            }
-
-            if (Utility.IsValidAttribute("modifiedby", logicalName))
-            {
-                entity["modifiedby"] = userRef;
-            }
-        }
-
         internal override OrganizationResponse Execute(OrganizationRequest orgRequest, EntityReference userRef)
         {
             var request = MakeRequest<CreateRequest>(orgRequest);
@@ -132,6 +102,44 @@ namespace DG.Tools.XrmMockup
             {
                 throw new FaultException(
                     $"Trying to create entity '{clonedEntity.LogicalName}', but the attributes had a circular reference");
+            }
+
+            // Stamp the created/modified system attributes on the record being persisted. This runs as
+            // part of the main operation (not a pre-stage) so the values surface via the post-image and
+            // the post-operation Target, matching Dataverse — they are absent from the pre-stage Target.
+            var createdOn = DateTime.UtcNow.Add(core.TimeOffset);
+            if (Utility.IsValidAttribute("createdon", entityMetadata))
+            {
+                if (Utility.IsValidAttribute("overriddencreatedon", entityMetadata) &&
+                    clonedEntity.Attributes.ContainsKey("overriddencreatedon") &&
+                    clonedEntity["overriddencreatedon"] is DateTime overriddencreatedon)
+                {
+                    if (overriddencreatedon > createdOn)
+                    {
+                        throw new FaultException(
+                            $"Trying to create entity '{clonedEntity.LogicalName}', but overriddencreatedon cannot be set to a date in the future");
+                    }
+
+                    clonedEntity["overriddencreatedon"] = createdOn;
+                    createdOn = overriddencreatedon;
+                }
+
+                clonedEntity["createdon"] = createdOn;
+            }
+
+            if (Utility.IsValidAttribute("createdby", entityMetadata))
+            {
+                clonedEntity["createdby"] = userRef;
+            }
+
+            if (Utility.IsValidAttribute("modifiedon", entityMetadata))
+            {
+                clonedEntity["modifiedon"] = createdOn;
+            }
+
+            if (Utility.IsValidAttribute("modifiedby", entityMetadata))
+            {
+                clonedEntity["modifiedby"] = userRef;
             }
 
             var transactioncurrencyId = "transactioncurrencyid";

--- a/src/XrmMockup365/Requests/UpdateRequestHandler.cs
+++ b/src/XrmMockup365/Requests/UpdateRequestHandler.cs
@@ -69,21 +69,6 @@ namespace DG.Tools.XrmMockup
             }
         }
 
-        internal override void InitializePreOperation(OrganizationRequest orgRequest, EntityReference userRef, Entity preImage)
-        {
-            var entity = orgRequest["Target"] as Entity;
-
-            if (Utility.IsValidAttribute("modifiedon", metadata.EntityMetadata.GetMetadata(entity.LogicalName)))
-            {
-                entity["modifiedon"] = preImage.Contains("modifiedon") ? preImage["modifiedon"] : null;
-            }
-
-            if (Utility.IsValidAttribute("modifiedby", metadata.EntityMetadata.GetMetadata(entity.LogicalName)))
-            {
-                entity["modifiedby"] = preImage.Contains("modifiedby") ? preImage["modifiedby"] : null;
-            }
-        }
-
         internal override OrganizationResponse Execute(OrganizationRequest orgRequest, EntityReference userRef)
         {
             var request = MakeRequest<UpdateRequest>(orgRequest);

--- a/tests/TestPluginAssembly365/Plugins/ContactSystemFieldsProbePlugin.cs
+++ b/tests/TestPluginAssembly365/Plugins/ContactSystemFieldsProbePlugin.cs
@@ -1,0 +1,76 @@
+namespace DG.Some.Namespace
+{
+    using System.Linq;
+    using Microsoft.Xrm.Sdk;
+    using DG.XrmFramework.BusinessDomain.ServiceContext;
+    using XrmPluginCore;
+    using XrmPluginCore.Enums;
+
+    /// <summary>
+    /// Diagnostic plugin used by the system-field alignment tests. When a Contact is created with
+    /// <see cref="Marker"/> as its first name, it records which system-managed attributes are present
+    /// in the Target at each stage (and in the post-image) into observable string fields:
+    ///   address1_line1 -> PreValidation Target
+    ///   address1_line2 -> PreOperation Target
+    ///   address1_line3 -> PostOperation post-image
+    ///   address1_city  -> PostOperation Target
+    /// This lets tests assert that system fields are absent from the pre-stage Target (matching
+    /// Dataverse) but present in the post-image and post-operation Target.
+    /// </summary>
+    public class ContactSystemFieldsProbePlugin : Plugin
+    {
+        public const string Marker = "ProbeSystemFields";
+
+        private static readonly string[] SystemFields =
+            { "ownerid", "createdon", "createdby", "modifiedon", "modifiedby", "statecode", "statuscode" };
+
+        public ContactSystemFieldsProbePlugin()
+        {
+#pragma warning disable CS0618 // Type or member is obsolete - disabled for testing purposes
+            RegisterPluginStep<Contact>(EventOperation.Create, ExecutionStage.PreValidation, ExecutePreValidation);
+            RegisterPluginStep<Contact>(EventOperation.Create, ExecutionStage.PreOperation, ExecutePreOperation);
+            RegisterPluginStep<Contact>(EventOperation.Create, ExecutionStage.PostOperation, ExecutePostOperation)
+                .WithPostImage();
+#pragma warning restore CS0618
+        }
+
+        internal static string Flags(Entity entity) =>
+            string.Join(",", SystemFields.Where(entity.Contains));
+
+        private static Entity GetProbeTarget(LocalPluginContext localContext)
+        {
+            var target = localContext.PluginExecutionContext.InputParameters["Target"] as Entity;
+            return target?.GetAttributeValue<string>("firstname") == Marker ? target : null;
+        }
+
+        private void ExecutePreValidation(LocalPluginContext localContext)
+        {
+            var target = GetProbeTarget(localContext);
+            if (target == null) return;
+            target["address1_line1"] = Flags(target);
+        }
+
+        private void ExecutePreOperation(LocalPluginContext localContext)
+        {
+            var target = GetProbeTarget(localContext);
+            if (target == null) return;
+            target["address1_line2"] = Flags(target);
+        }
+
+        private void ExecutePostOperation(LocalPluginContext localContext)
+        {
+            var target = GetProbeTarget(localContext);
+            if (target == null) return;
+
+            var postImage = localContext.PluginExecutionContext.PostEntityImages.Values.First();
+
+            // Post-operation writes to Target are not persisted, so record the observations via an update.
+            var record = new Entity(target.LogicalName, target.Id)
+            {
+                ["address1_line3"] = Flags(postImage),
+                ["address1_city"] = Flags(target),
+            };
+            localContext.OrganizationService.Update(record);
+        }
+    }
+}

--- a/tests/XrmMockup365Test/TestPlugins.cs
+++ b/tests/XrmMockup365Test/TestPlugins.cs
@@ -6,6 +6,7 @@ using DG.Tools.XrmMockup;
 using Microsoft.Xrm.Sdk;
 using Xunit;
 using TestPluginAssembly365.Plugins.LegacyDaxif;
+using DG.Some.Namespace;
 
 namespace DG.XrmMockupTest
 {
@@ -109,6 +110,58 @@ namespace DG.XrmMockupTest
                 con = Contact.Retrieve(orgAdminService, con.Id, x => x.LastName, x => x.CreatedOn);
                 Assert.True(!string.IsNullOrEmpty(con.LastName));
                 Assert.Equal(con.CreatedOn.ToString(), con.LastName);
+            }
+        }
+
+        [Fact]
+        public void TestSystemFieldsAbsentFromPreStageTargetOnCreate()
+        {
+            // Matches Dataverse: system-managed fields the caller did not set must not appear in the
+            // Target during the PreValidation/PreOperation stages.
+            var contact = new Contact { FirstName = ContactSystemFieldsProbePlugin.Marker };
+            contact.Id = orgAdminService.Create(contact);
+
+            var probed = Contact.Retrieve(orgAdminService, contact.Id,
+                x => x.Address1_Line1, x => x.Address1_Line2);
+
+            // Empty flag strings are normalised to null on create, confirming no system fields were present.
+            Assert.True(string.IsNullOrEmpty(probed.Address1_Line1)); // PreValidation Target
+            Assert.True(string.IsNullOrEmpty(probed.Address1_Line2)); // PreOperation Target
+        }
+
+        [Fact]
+        public void TestCallerSetOwnerVisibleInPreStageTargetOnCreate()
+        {
+            // A system field the caller DID set stays visible in the pre-stage Target.
+            var contact = new Contact
+            {
+                FirstName = ContactSystemFieldsProbePlugin.Marker,
+                OwnerId = testUser1.ToEntityReference(),
+            };
+            contact.Id = orgAdminService.Create(contact);
+
+            var probed = Contact.Retrieve(orgAdminService, contact.Id,
+                x => x.Address1_Line1, x => x.Address1_Line2);
+
+            Assert.Contains("ownerid", probed.Address1_Line1);         // PreValidation Target
+            Assert.Contains("ownerid", probed.Address1_Line2);         // PreOperation Target
+            Assert.DoesNotContain("createdon", probed.Address1_Line1); // still resolved later
+        }
+
+        [Fact]
+        public void TestSystemFieldsPresentInPostImageAndPostTargetOnCreate()
+        {
+            var contact = new Contact { FirstName = ContactSystemFieldsProbePlugin.Marker };
+            contact.Id = orgAdminService.Create(contact);
+
+            var probed = Contact.Retrieve(orgAdminService, contact.Id,
+                x => x.Address1_Line3, x => x.Address1_City);
+
+            foreach (var field in new[]
+                { "ownerid", "createdon", "createdby", "modifiedon", "modifiedby", "statecode", "statuscode" })
+            {
+                Assert.Contains(field, probed.Address1_Line3); // post-image
+                Assert.Contains(field, probed.Address1_City);  // post-operation Target
             }
         }
 


### PR DESCRIPTION
System fields were leaked into the plugin Target during pre-stages: ownerid was injected before PreValidation, and created/modified timestamps before PreOperation. Dataverse resolves these during the main operation, exposing them only via the post-image and the post-operation Target.

- Core: stop injecting ownerid in HandleInternalPreOperations (keep id); extend CopySystemAttributes to reflect ownerid/ownership/statecode/ statuscode onto the post-operation Target (add OptionSetValue support).
- CreateRequestHandler: move created/modified stamping from the pre-stage into the main operation on the persisted clone; resolve the effective owner on a local clone for the access checks only.
- UpdateRequestHandler: drop the pre-stage modified stamping (Utility.Touch already sets the persisted values).
- Tests: add ContactSystemFieldsProbePlugin and assertions that system fields are absent from the pre-stage Target, a caller-set ownerid stays visible, and the fields are present in the post-image and post-Target.